### PR TITLE
동행 게시글 수정 기능에서 PATCH 삭제, Entity 관계 수정, 와인바 조회 리턴 타입 수정.

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -91,22 +91,13 @@ public class BoardController {
         return null;
     }
 
-    @PatchMapping("/{boardId}")
-    public ResponseEntity<Board> boardUpdatePATCH(
+    @PutMapping("/{boardId}")
+    public ResponseEntity<Board> boardUpdate(
             @PathVariable Long boardId,
             @RequestBody BoardUpdateRequest boardUpdateRequest
     ) {
         return ResponseEntity.ok(
                 boardService.updateBoard(boardId, boardUpdateRequest));
-    }
-
-    @PutMapping("/{boardId}")
-    public ResponseEntity<Board> boardUpdatePUT(
-            @PathVariable Long boardId,
-            @RequestBody BoardUpdateRequest boardUpdateRequest
-    ) {
-        return ResponseEntity.ok(
-                boardService.updateBoard2(boardId, boardUpdateRequest));
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -16,8 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -78,7 +76,7 @@ public class BoardService {
             String winebarName, Pageable pageable
     ) {
         Winebar winebar = this.wineBarRepository.findByName(winebarName)
-                .orElseThrow(() -> new RuntimeException("the wine does not exists"));
+                .orElseThrow(() -> new RuntimeException("the winebar does not exists"));
 
         return boardRepository.findByWinebar(winebar, pageable)
                 .map(BoardSearchResponse::fromEntity);
@@ -100,39 +98,7 @@ public class BoardService {
                 .map(BoardSearchResponse::fromEntity);
     }
 
-    public Board updateBoard(Long id, BoardUpdateRequest boardUpdateRequest) {
-        Board nowBoard = boardRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("the board does not exists"));
-
-        updateFunction(boardUpdateRequest, nowBoard);
-        return boardRepository.save(nowBoard);
-    }
-
-    private static void updateFunction(
-            BoardUpdateRequest boardUpdateRequest, Board nowBoard) {
-        List<BoardUpdateRequest> list = new ArrayList<>();
-        list.add(boardUpdateRequest);
-
-        for (BoardUpdateRequest request : list) {
-            if (request.getName() != null) {
-                nowBoard.setName(request.getName());
-            }
-            if (request.getDate() != null) {
-                nowBoard.setDate(request.getDate());
-            }
-            if (request.getWineName() != null) {
-                nowBoard.setWineName(request.getWineName());
-            }
-            if (request.getHeadcount() != nowBoard.getHeadcount()) {
-                nowBoard.setHeadcount(request.getHeadcount());
-            }
-            if (request.getContents() != null) {
-                nowBoard.setContents(request.getContents());
-            }
-        }
-    }
-
-    public Board updateBoard2(Long boardId, BoardUpdateRequest request) {
+    public Board updateBoard(Long boardId, BoardUpdateRequest request) {
         Board nowBoard = boardRepository.findById(boardId)
                 .orElseThrow(() -> new RuntimeException("the board does not exists"));
         ;

--- a/src/main/java/com/be/friendy/warendy/domain/chat/entity/ConnectedChat.java
+++ b/src/main/java/com/be/friendy/warendy/domain/chat/entity/ConnectedChat.java
@@ -5,8 +5,6 @@ import com.be.friendy.warendy.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.List;
-
 @Getter
 @Builder
 @ToString
@@ -26,9 +24,5 @@ public class ConnectedChat {
     @ManyToOne
     @JoinColumn(name = "CHATROOM_ID", nullable = false)
     private Chatroom chatroom;
-
-    @OneToMany
-    @JoinColumn(name = "MESSAGE_ID")
-    private List<Message> message;
 
 }

--- a/src/main/java/com/be/friendy/warendy/domain/member/entity/Member.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/entity/Member.java
@@ -1,11 +1,7 @@
 package com.be.friendy.warendy.domain.member.entity;
 
-import com.be.friendy.warendy.domain.chat.entity.ConnectedChat;
-import com.be.friendy.warendy.domain.chat.entity.Notification;
 import com.be.friendy.warendy.domain.common.BaseEntity;
-import com.be.friendy.warendy.domain.favorite.entity.Favorite;
 import com.be.friendy.warendy.domain.member.entity.constant.Role;
-import com.be.friendy.warendy.domain.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -16,7 +12,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 @Getter
 @Builder
@@ -33,22 +28,6 @@ public class Member extends BaseEntity implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 시퀀스 전략 선언
     @Column(name = "MEMBER_ID") // 아이디에 해당하는 컬럼명 선언
     private Long id;
-
-    @OneToMany
-    @JoinColumn(name = "REVIEW_ID")
-    private List<Review> reviewList;
-
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "FAVORITE_ID")
-    private List<Favorite> favoriteList;
-
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "CONNECTED_CHAT_ID")
-    private List<ConnectedChat> connectedChatList;
-
-    @OneToMany
-    @JoinColumn(name = "NOTIFICATION_ID")
-    private List<Notification> notificationList;
 
     private String email;
     private String password;

--- a/src/main/java/com/be/friendy/warendy/domain/wine/entity/Wine.java
+++ b/src/main/java/com/be/friendy/warendy/domain/wine/entity/Wine.java
@@ -1,8 +1,6 @@
 package com.be.friendy.warendy.domain.wine.entity;
 
 import com.be.friendy.warendy.domain.common.BaseEntity;
-import com.be.friendy.warendy.domain.favorite.entity.Favorite;
-import com.be.friendy.warendy.domain.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,15 +17,6 @@ public class Wine extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 시퀀스 전략 선언
     @Column(name = "WINE_ID") // 아이디에 해당하는 컬럼명 선언
     private Long id;
-
-    @OneToMany
-    @JoinColumn(name = "REVIEW_ID")
-    private List<Review> reviews;
-
-    @OneToMany
-    @JoinColumn(name = "FAVORITE_ID")
-    private List<Favorite> favorites;
-
     private String name;
     private Integer vintage;
     private String price;
@@ -38,6 +27,8 @@ public class Wine extends BaseEntity {
     private Integer acidity;
     private Double alcohol;
     private String grapes;
+    @ElementCollection(fetch = FetchType.LAZY)
+    private List<String> paring;
     private String region;
     private String type;
     private String winery;

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/controller/WinebarController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/controller/WinebarController.java
@@ -1,5 +1,6 @@
 package com.be.friendy.warendy.domain.winebar.controller;
 
+import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import com.be.friendy.warendy.domain.winebar.service.WineBarService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,7 @@ public class WinebarController {
     private final WineBarService wineBarService;
 
     @GetMapping("/winebars")
-    public ResponseEntity<List> wineBarSearch (
+    public ResponseEntity<Winebar> wineBarSearch (
             @RequestParam Double lat, @RequestParam Double lnt
     ) {
         return ResponseEntity.ok(wineBarService.searchWinebar(lat, lnt));

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/entity/Winebar.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/entity/Winebar.java
@@ -2,13 +2,9 @@ package com.be.friendy.warendy.domain.winebar.entity;
 
 
 import com.be.friendy.warendy.domain.common.BaseEntity;
-import com.be.friendy.warendy.domain.favorite.entity.Favorite;
-import com.be.friendy.warendy.domain.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
-
-import java.util.List;
 
 @Getter
 @ToString
@@ -24,14 +20,6 @@ public class Winebar extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 시퀀스 전략 선언
     @Column(name = "WINEBAR_ID") // 아이디에 해당하는 컬럼명 선언
     private Long id;
-
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = false)
-    @JoinColumn(name = "REVIEW_ID")
-    private List<Review> reviewList;
-
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = false)
-    @JoinColumn(name = "FAVORITE_ID")
-    private List<Favorite> favoriteList;
 
     private String name;
 

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/service/WineBarService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/service/WineBarService.java
@@ -6,16 +6,15 @@ import com.be.friendy.warendy.domain.winebar.repository.WinebarRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @AllArgsConstructor
 public class WineBarService {
 
     WinebarRepository winebarRepository;
 
-    public List<Winebar> searchWinebar(Double lat, Double lnt) {
-        return winebarRepository.findAllByLatAndLnt(lat, lnt);
+    public Winebar searchWinebar(Double lat, Double lnt) {
+        return winebarRepository.findByLatAndLnt(lat, lnt)
+                .orElseThrow(() -> new RuntimeException("the winebar does not exists"));
     }
 
 }


### PR DESCRIPTION
### 게시글 수정 PUT 통신으로 통일.
-  #### changes
    -  PUT 과 PATCH 방식 중 PUT 선택, PATCH 삭제.
-  #### 상세 내용
    -  PUT 방식과 PATCH 방식 모두 있었고, PATCH 방식의 번거로움 ( 조건을 하나하나 체크, 프론트 엔트 통신과도 번거로움) 때문에 PUT 방식 선택, PATCH 방식 삭제 후 update 함수 명 rename.

### Entity 관계 수정
-  #### changes
    - 모든 entity 양방향 관계 -> 단방향 관계
-  #### 상세 내용
    - 양방향 관계 시 어떤 사이드 이펙트가 발생할지 모르기 때문에 단방향 관계로 수정
    - entity 안 OneToMant annotation 달려 있는 변수 모두 삭제. ManyToOne 지향.

### 와인바 조회 리턴 타입 수정.
-  #### changes
    - List<Winebar>에서 Winebar 로 수정.
-  #### 상세 내용
    -  타입 지정 실수로 인한 수정.
    - 위도, 경도로 조회 시 하나의 winebar 만 조회가 되어야함.