### PR TITLE
통행 게시글 TEST CODE 추가

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -25,9 +25,9 @@ import java.time.LocalDate;
 public class BoardController {
     private final BoardService boardService;
 
-    @PostMapping("/winebars/{winebarId}")
+    @PostMapping("/winebars/{winebar-id}")
     public ResponseEntity<BoardCreateResponse> boardCreate(
-            @PathVariable Long winebarId,
+            @PathVariable(value = "winebar-id") Long winebarId,
             @RequestBody BoardCreateRequest request
     ) {
         return ResponseEntity.ok(boardService.creatBoard(winebarId, request));
@@ -91,18 +91,18 @@ public class BoardController {
         return null;
     }
 
-    @PutMapping("/{boardId}")
+    @PutMapping("/{board-id}")
     public ResponseEntity<Board> boardUpdate(
-            @PathVariable Long boardId,
+            @PathVariable(value = "board-id") Long boardId,
             @RequestBody BoardUpdateRequest boardUpdateRequest
     ) {
         return ResponseEntity.ok(
                 boardService.updateBoard(boardId, boardUpdateRequest));
     }
 
-    @DeleteMapping("/{boardId}")
+    @DeleteMapping("/{board-id}")
     public ResponseEntity<String> boardDelete(
-            @PathVariable Long boardId
+            @PathVariable(value = "board-id") Long boardId
     ) {
         boardService.deleteBoard(boardId);
         return ResponseEntity.ok("board is deleted!");

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
@@ -12,8 +12,8 @@ import lombok.*;
 @Builder
 public class BoardSearchResponse {
 
+    private String name;        // board 제목
     private String winebarName;
-    private String name;
     private String creator;
     private String date;
     private String wineName;
@@ -22,8 +22,8 @@ public class BoardSearchResponse {
 
     public static BoardSearchResponse fromEntity(Board board) {
         return BoardSearchResponse.builder()
-                .winebarName(board.getWinebar().getName())
                 .name(board.getName())
+                .winebarName(board.getWinebar().getName())
                 .creator(board.getCreator())
                 .date(board.getDate())
                 .wineName(board.getWineName())

--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -8,6 +8,8 @@ import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.repository.BoardRepository;
 import com.be.friendy.warendy.domain.member.entity.Member;
 import com.be.friendy.warendy.domain.member.repository.MemberRepository;
+import com.be.friendy.warendy.domain.wine.entity.Wine;
+import com.be.friendy.warendy.domain.wine.repository.WineRepository;
 import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import com.be.friendy.warendy.domain.winebar.repository.WinebarRepository;
 import lombok.AllArgsConstructor;
@@ -24,6 +26,7 @@ public class BoardService {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final WinebarRepository wineBarRepository;
+    private final WineRepository wineRepository;
 
     public BoardCreateResponse creatBoard(
             Long winebarId, BoardCreateRequest createRequest) {
@@ -34,10 +37,10 @@ public class BoardService {
 
         Winebar winebar = wineBarRepository
                 .findById(winebarId)
-                .orElseThrow(() -> new RuntimeException("winebar does not exists"));
+                .orElseThrow(() -> new RuntimeException("winebar does not exist"));
 
         Member member = memberRepository.findById(createRequest.getMemberId())
-                .orElseThrow(() -> new RuntimeException("user does not exists"));
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
 
         return BoardCreateResponse.fromEntity(boardRepository.save(
                 Board.builder()
@@ -68,15 +71,18 @@ public class BoardService {
     public Page<BoardSearchResponse> searchBoardByWineName(
             String wineName, Pageable pageable
     ) {
-        return boardRepository.findByWineName(wineName, pageable)
+        Wine wine = wineRepository.findByName(wineName)
+                .orElseThrow(() -> new RuntimeException("the wine does not exist"));
+
+        return boardRepository.findByWineName(wine.getName(), pageable)
                 .map(BoardSearchResponse::fromEntity);
     }
 
     public Page<BoardSearchResponse> searchBoardByWinebarName(
             String winebarName, Pageable pageable
     ) {
-        Winebar winebar = this.wineBarRepository.findByName(winebarName)
-                .orElseThrow(() -> new RuntimeException("the winebar does not exists"));
+        Winebar winebar = wineBarRepository.findByName(winebarName)
+                .orElseThrow(() -> new RuntimeException("the winebar does not exist"));
 
         return boardRepository.findByWinebar(winebar, pageable)
                 .map(BoardSearchResponse::fromEntity);
@@ -85,7 +91,10 @@ public class BoardService {
     public Page<BoardSearchResponse> searchBoardByCreator(
             String creator, Pageable pageable
     ) {
-        return boardRepository.findByCreator(creator, pageable)
+        Member member = memberRepository.findByNickname(creator)
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        return boardRepository.findByCreator(member.getNickname(), pageable)
                 .map(BoardSearchResponse::fromEntity);
     }
 
@@ -100,7 +109,7 @@ public class BoardService {
 
     public Board updateBoard(Long boardId, BoardUpdateRequest request) {
         Board nowBoard = boardRepository.findById(boardId)
-                .orElseThrow(() -> new RuntimeException("the board does not exists"));
+                .orElseThrow(() -> new RuntimeException("the board does not exist"));
         ;
         nowBoard.updateBoardInfo(request);
         return boardRepository.save(nowBoard);
@@ -108,7 +117,8 @@ public class BoardService {
 
     public void deleteBoard(Long boardId) {
         Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new RuntimeException("The board does not exist"));
+                .orElseThrow(() -> new RuntimeException("the board does not exist"));
+        boardRepository.save(board); // test 코드에서 확인 위한
         boardRepository.delete(board);
     }
 

--- a/src/main/java/com/be/friendy/warendy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/repository/MemberRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByNickname(String nickname);
+
     Optional<Member> findById(Long memberId);
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/be/friendy/warendy/domain/member/service/MemberService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.be.friendy.warendy.domain.member.service;
 
-import com.be.friendy.warendy.config.jwt.TokenProvider;
 import com.be.friendy.warendy.domain.member.dto.request.SignInRequest;
 import com.be.friendy.warendy.domain.member.dto.request.SignUpRequest;
 import com.be.friendy.warendy.domain.member.dto.request.UpdateRequest;
@@ -8,22 +7,10 @@ import com.be.friendy.warendy.domain.member.dto.response.InfoResponse;
 import com.be.friendy.warendy.domain.member.entity.Member;
 import com.be.friendy.warendy.domain.member.entity.constant.Role;
 import com.be.friendy.warendy.domain.member.repository.MemberRepository;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Map;
 
 @Service
 @AllArgsConstructor
@@ -35,7 +22,7 @@ public class MemberService extends DefaultOAuth2UserService {
     public InfoResponse signUp(SignUpRequest request) {
         //이미 들록된 유저인지 확인
         boolean exists = memberRepository.existsByEmail(request.getEmail());
-        if(exists) {
+        if (exists) {
             throw new RuntimeException("already exists");
         }
 
@@ -45,7 +32,7 @@ public class MemberService extends DefaultOAuth2UserService {
 
     public Member signIn(SignInRequest member) {
         Member user = memberRepository.findByEmail(member.getEmail())
-                .orElseThrow(() -> new RuntimeException("user does not exists"));
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
 
         if (!this.passwordEncoder.matches(member.getPassword(), user.getPassword())) {
             throw new RuntimeException("wrong password");
@@ -54,9 +41,9 @@ public class MemberService extends DefaultOAuth2UserService {
         return user;
     }
 
-    public void updateMember(UpdateRequest request, String email){
+    public void updateMember(UpdateRequest request, String email) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("user does not exists"));
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
         member.updateMemberInfo(request.getEmail(), request.getPassword(), request.getNickname(), request.getAvatar(),
                 request.getMbti(), request.getBody(), request.getDry(), request.getTannin(), request.getAcidity());
         memberRepository.save(member);
@@ -64,12 +51,12 @@ public class MemberService extends DefaultOAuth2UserService {
 
     public InfoResponse getMemberInfo(String email) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("user does not exists"));
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
 
         return InfoResponse.fromEntity(member);
     }
 
-    public void deleteAccount(Long memberId){
+    public void deleteAccount(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("user does not exist"));
         memberRepository.delete(member);
@@ -77,10 +64,10 @@ public class MemberService extends DefaultOAuth2UserService {
 
     public Member loadUserByEmail(String email) {
         return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("already exists"));
+                .orElseThrow(() -> new RuntimeException("already exist"));
     }
 
-    private Member setAccount(SignUpRequest request){
+    private Member setAccount(SignUpRequest request) {
         return Member.builder()
                 .email(request.getEmail())
                 .password(request.getPassword())

--- a/src/main/java/com/be/friendy/warendy/domain/wine/entity/Wine.java
+++ b/src/main/java/com/be/friendy/warendy/domain/wine/entity/Wine.java
@@ -27,7 +27,6 @@ public class Wine extends BaseEntity {
     private Integer acidity;
     private Double alcohol;
     private String grapes;
-    @ElementCollection(fetch = FetchType.LAZY)
     private List<String> paring;
     private String region;
     private String type;

--- a/src/main/java/com/be/friendy/warendy/domain/wine/repository/WineRepository.java
+++ b/src/main/java/com/be/friendy/warendy/domain/wine/repository/WineRepository.java
@@ -1,0 +1,12 @@
+package com.be.friendy.warendy.domain.wine.repository;
+
+import com.be.friendy.warendy.domain.wine.entity.Wine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface WineRepository extends JpaRepository<Wine, Long> {
+    Optional<Wine> findByName(String wineName);
+}

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -1,0 +1,242 @@
+package com.be.friendy.warendy.domain.board.controller;
+
+import com.be.friendy.warendy.config.AppConfig;
+import com.be.friendy.warendy.config.jwt.TokenProvider;
+import com.be.friendy.warendy.config.jwt.filter.JwtAuthenticationFilter;
+import com.be.friendy.warendy.config.security.SecurityConfig;
+import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
+import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
+import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
+import com.be.friendy.warendy.domain.board.entity.Board;
+import com.be.friendy.warendy.domain.board.service.BoardService;
+import com.be.friendy.warendy.domain.member.entity.Member;
+import com.be.friendy.warendy.domain.member.entity.constant.Role;
+import com.be.friendy.warendy.domain.winebar.entity.Winebar;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = BoardController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = AppConfig.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = TokenProvider.class)
+        }
+)
+class BoardControllerTest {
+
+    @MockBean
+    private BoardService boardService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    //json에서 오브젝트로 오브젝트에서 json으로 바꿔주는
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Create! - board")
+    void successCreateBoard() throws Exception {
+        //given
+        given(boardService.creatBoard(anyLong(), any()))
+                .willReturn(BoardCreateResponse.builder()
+                        .memberId(1L)
+                        .winebarId(1L)
+                        .name("board name")
+                        .creator("nick name")
+                        .date("2010-1-1")
+                        .wineName("wine name")
+                        .headcount(4)
+                        .contents("hello world!")
+                        .build());
+        //when
+        //then
+        mockMvc.perform(post("/boards/winebars/1")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .content(objectMapper
+                                .writeValueAsString(BoardCreateRequest
+                                        .builder()
+                                        .memberId(14L)
+                                        .name("board name1")
+                                        .creator("nick name1")
+                                        .date("2010-1-11")
+                                        .wineName("wine name1")
+                                        .headcount(4)
+                                        .contents("hello world!1")
+                                        .build())))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.memberId").value(1))
+                .andExpect(
+                        jsonPath("$.name").value("board name"))
+                .andExpect(
+                        jsonPath("$.contents")
+                                .value("hello world!"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Update! - board")
+    void successUpdateBoard() throws Exception {
+        //given
+        given(boardService.updateBoard(anyLong(), any()))
+                .willReturn(Board.builder().id(1L)
+                        .member(Member.builder().id(1L)
+                                .email("asdf@gmail.com")
+                                .password("asdfasdfasdf")
+                                .nickname("nick name").avatar("asdfasdfasdf")
+                                .mbti("istp")
+                                .role(Role.MEMBER).oauthType("fasdf")
+                                .body(1).dry(1).tannin(1).acidity(1)
+                                .build())
+                        .winebar(Winebar.builder().id(1L)
+                                .name("AAA").picture("asdfasd")
+                                .address("Asdfasdf").lnt(0.0).lat(0.0)
+                                .rating(0.0).reviews(1)
+                                .build())
+                        .name("board name")
+                        .creator("nick name")
+                        .date("2010-1-1")
+                        .wineName("wine name")
+                        .headcount(4)
+                        .contents("hello world!")
+                        .build());
+
+        //when
+        //then
+        mockMvc.perform(put("/boards/{board-id}", 1)
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .content(objectMapper
+                                .writeValueAsString(BoardUpdateRequest
+                                        .builder()
+                                        .memberId(14L)
+                                        .winebarId(15L)
+                                        .name("board name1")
+                                        .creator("nick name1")
+                                        .date("2010-1-11")
+                                        .wineName("wine name1")
+                                        .headcount(4)
+                                        .contents("hello world!1")
+                                        .build())))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.member.id").value(1))
+                .andExpect(
+                        jsonPath("$.winebar.id").value(1))
+                .andExpect(
+                        jsonPath("$.name").value("board name"))
+                .andExpect(
+                        jsonPath("$.contents").value("hello world!"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Search with a Creator! - board")
+    void successSearchBoardByCreator() throws Exception {
+        //given
+        List<BoardSearchResponse> boardSearchResponses =
+                Arrays.asList(
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar")
+                                .name("board")
+                                .creator("Hong")
+                                .date("2000-1-1")
+                                .wineName("wine")
+                                .headcount(4)
+                                .contents("content yo")
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar2")
+                                .name("board2")
+                                .creator("Hong")
+                                .date("2000-1-12")
+                                .wineName("wine2")
+                                .headcount(5)
+                                .contents("content yo2")
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar3")
+                                .name("board3")
+                                .creator("Hong")
+                                .date("2000-1-13")
+                                .wineName("wine3")
+                                .headcount(6)
+                                .contents("content yo3")
+                                .build()
+                );
+        PageImpl<BoardSearchResponse> boardSearchResponsePage =
+                new PageImpl<>(boardSearchResponses);
+        given(boardService.searchBoardByCreator(anyString(), any()))
+                .willReturn(boardSearchResponsePage);
+        //when
+        //then
+        mockMvc.perform(get("/boards/creator?creator=1&page=0"))
+                .andDo(print())
+                .andExpect(jsonPath("$.content[0].creator")
+                        .value("Hong"))
+                .andExpect(jsonPath("$.content[1].creator")
+                        .value("Hong"))
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Delete - board")
+    void successDeleteBoard() throws Exception {
+        //given
+        Long deletedBoardID = 1L;
+        //when
+        //then
+        mockMvc.perform(delete("/boards/{boardId}", deletedBoardID)
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    @DisplayName("failed search for wine name - board")
+    void failedSearchBoardByWineName() throws Exception {
+        //given
+        given(boardService.searchBoardByWinebarName(anyString(), any()))
+                .willThrow(new RuntimeException("the wine does not exist"));
+        //when
+        //then
+        mockMvc.perform(get("/boards/wine-name?wineName={}", "AAA")
+                .contentType(MediaType.APPLICATION_JSON).with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
@@ -1,0 +1,350 @@
+package com.be.friendy.warendy.domain.board.service;
+
+import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
+import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
+import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
+import com.be.friendy.warendy.domain.board.entity.Board;
+import com.be.friendy.warendy.domain.board.repository.BoardRepository;
+import com.be.friendy.warendy.domain.member.entity.Member;
+import com.be.friendy.warendy.domain.member.entity.constant.Role;
+import com.be.friendy.warendy.domain.member.repository.MemberRepository;
+import com.be.friendy.warendy.domain.wine.repository.WineRepository;
+import com.be.friendy.warendy.domain.winebar.entity.Winebar;
+import com.be.friendy.warendy.domain.winebar.repository.WinebarRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+    @Mock
+    private BoardRepository boardRepository;
+    @Mock
+    private WinebarRepository wineBarRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private WineRepository wineRepository;
+
+    @InjectMocks
+    private BoardService boardService;
+
+    @Test
+    @DisplayName("success create! - board")
+    void successCreateBoard() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(1L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.of(member1));
+        given(wineBarRepository.findById(anyLong()))
+                .willReturn(Optional.of(winebar1));
+        given(boardRepository.save(any()))
+                .willReturn(Board.builder()
+                        .id(1L)
+                        .member(member1)
+                        .winebar(winebar1)
+                        .name("A")
+                        .creator("A")
+                        .date("2010-1-13")
+                        .wineName("123")
+                        .headcount(4)
+                        .contents("123")
+                        .build());
+        //when
+        BoardCreateRequest createRequest = BoardCreateRequest.builder()
+                .memberId(1L)
+                .name("board name")
+                .creator("nick name")
+                .date("2010-1-1")
+                .wineName("wine name")
+                .headcount(6)
+                .contents("hello world!")
+                .build();
+        BoardCreateResponse createResponse =
+                boardService.creatBoard(13L, createRequest);
+        //then - given에서 값과 일치
+        assertEquals(13L, createResponse.getMemberId());
+        assertEquals(1L, createResponse.getWinebarId());
+        assertEquals("A", createResponse.getCreator());
+        assertEquals(4, createResponse.getHeadcount());
+    }
+
+    @Test
+    @DisplayName("success search with a creator! - board")
+    void successSearchBoardByCreator() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(1L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        List<Board> boardList = Arrays.asList(
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("A").creator("A")
+                        .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                        .build(),
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("Ab").creator("Ab")
+                        .date("2010-1-13b").wineName("123b").headcount(45).contents("123b")
+                        .build(),
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("Ac").creator("Ac")
+                        .date("2010-1-13c").wineName("123c").headcount(46).contents("123c")
+                        .build()
+        );
+        given(memberRepository.findByNickname(anyString()))
+                .willReturn(Optional.ofNullable(member1));
+        given(boardRepository.findByCreator(anyString(), any()))
+                .willReturn(new PageImpl<>(boardList));
+        //when
+        Pageable pageable = PageRequest.of(0, 3);
+        Page<BoardSearchResponse> boardPage
+                = boardService.searchBoardByCreator("a", pageable);
+        //then
+        assertEquals(3, boardPage.getTotalElements());
+        assertEquals(1, boardPage.getTotalPages());
+        assertEquals("A", boardPage.getContent().get(0).getCreator());
+        assertEquals("123b", boardPage.getContent().get(1).getWineName());
+        assertEquals("AA", boardPage.getContent().get(2).getWinebarName());
+    }
+
+    @Test
+    @DisplayName("success update! - board")
+    void successUpdateBoard() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(16L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        Board targetBoard = Board.builder()
+                .id(1L).member(member1).winebar(winebar1).name("A").creator("A")
+                .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                .build();
+        given(boardRepository.save(any())).willReturn(targetBoard);
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(targetBoard));
+        //when
+        BoardUpdateRequest request = BoardUpdateRequest.builder()
+                .memberId(1L)
+                .winebarId(1L)
+                .name("name1")
+                .creator("creator!")
+                .date("2020-1-1")
+                .wineName("AAA")
+                .headcount(5)
+                .contents("empty at all")
+                .build();
+        Board board = boardService.updateBoard(13L, request);
+        //then
+        assertEquals(5, board.getHeadcount());
+        assertEquals(13, board.getMember().getId());
+        assertEquals(16, board.getWinebar().getId());
+        assertEquals("AAA", board.getWineName());
+    }
+
+    @Test
+    @DisplayName("success delete! - board")
+    void successDeleteBoard() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(16L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        Board targetBoard = Board.builder()
+                .id(1L).member(member1).winebar(winebar1).name("A").creator("A")
+                .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                .build();
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(targetBoard));
+        ArgumentCaptor<Board> captor = ArgumentCaptor.forClass(Board.class);
+        //when
+        boardService.deleteBoard(123L);
+        //then
+        verify(boardRepository, times(1)).save(captor.capture());
+        assertEquals(1, captor.getValue().getId());
+    }
+
+    @Test
+    @DisplayName("fail create : Duplication Name ! - board")
+    void failedCreateBoardDuplicationName() {
+        //given
+        given(boardRepository.existsByName(any())).willReturn(true);
+        //when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.creatBoard(1l,
+                        BoardCreateRequest.builder()
+                                .memberId(1L)
+                                .name("name")
+                                .creator("creator")
+                                .date("2020-1-1")
+                                .wineName("winename")
+                                .headcount(1)
+                                .contents("cont")
+                                .build()));
+        //then
+        assertEquals("already exists",exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("fail create : Not Found Winebar ! - board")
+    void failedCreateBoardWinebarNotFound() {
+        //given
+        given(wineBarRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.creatBoard(1l,
+                        BoardCreateRequest.builder()
+                                .memberId(1L)
+                                .name("name")
+                                .creator("creator")
+                                .date("2020-1-1")
+                                .wineName("winename")
+                                .headcount(1)
+                                .contents("cont")
+                                .build()));
+        //then
+        assertEquals("winebar does not exist",exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("fail search : Not Found Wine ! - board")
+    void failedSearchBoardWineNotFound() {
+        //given
+        given(wineRepository.findByName(anyString())).willReturn(Optional.empty());
+        //when
+        Pageable pageable = PageRequest.of(0,3);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.searchBoardByWineName("A", pageable));
+        //then
+        assertEquals("the wine does not exist",exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("fail search : Not Found User ! - board")
+    void failedSearchBoardMemberNotFound() {
+        //given
+        given(memberRepository.findByNickname(anyString())).willReturn(Optional.empty());
+        //when
+        Pageable pageable = PageRequest.of(0,3);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.searchBoardByCreator("A", pageable));
+        //then
+        assertEquals("user does not exist",exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("fail update- board")
+    void failedUpdateBoard() {
+        //given
+        given(boardRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.updateBoard(1L,
+                        BoardUpdateRequest.builder()
+                                .memberId(1L)
+                                .name("name")
+                                .creator("creator")
+                                .date("2020-1-1")
+                                .wineName("winename")
+                                .headcount(1)
+                                .contents("cont")
+                                .build()));
+        //then
+        assertEquals("the board does not exist",exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("fail delete! - board")
+    void failedDeleteBoard() {
+        //given
+        given(boardRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        RuntimeException exception =  assertThrows(RuntimeException.class,
+                () -> boardService.deleteBoard(1L));
+        //then
+        assertEquals("the board does not exist",exception.getMessage());
+    }
+}


### PR DESCRIPTION
### 동행 게시글 TEST CODE 추가
CRUD 각 기능 단위 테스트 하기 위한 코드.
-  #### CHANGES
    -  board controller test (CRUD) 추가.
    -  board service test (CRUD) 추가.
-  #### 상세내용
    -  컨트롤러단 CRUD 성공 케이스, 조회 실패 케이스.
        -  creator로 게시글 조회 성공.
        -  일치하는 와인 이름 없어서(와인이 없어서) 조회 실패.
    -  서비스단  CRUD 성공케이스, 실패 케이스.
        -  성공
            -  creator 조회 성공
        -  실패
            -  중복 이름으로 작성 실패.
            -  일치하는 와인바를 찾을 수 없어서 작성 실패
            -  일치하는 와인을 찾을 수 없어서 조회 실패
            -  일치하는 user가 없어서 조회 실패

### 리스트 타입 데이터 컬럼 삽입 방식 변경
wine 테이블 paring 컬럼에 리스트 담는 방식 변경
-  #### CHANGES
    - 기존에 붙어있던 @ElementCollection 삭제

### 규칙 위배 변수명, 오탈자 수정.
-  #### CHANGES
    -  @PathVariable(value = " ") 이용해 url에 있는 값 그대로 사용하지 않고 규칙에 맞는 이름으로 변경해서 사용.
    -  일부 exists -> exist 로 수정.