### PR TITLE
동행 게시글 단 건 상세 조회 기능 추가, boardEntity time 컬럼 추가.

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -4,6 +4,7 @@ package com.be.friendy.warendy.domain.board.controller;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.service.BoardService;
@@ -38,6 +39,13 @@ public class BoardController {
             @PageableDefault(size = 3) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService.searchBoard(pageable));
+    }
+
+    @GetMapping("/{board-id}/detail")
+    public ResponseEntity<BoardSearchDetailResponse> boardSearchDetail(
+            @PathVariable("board-id") Long boardId
+    ) {
+        return ResponseEntity.ok(boardService.searchBoardDetail(boardId));
     }
 
     @GetMapping("/board-name")
@@ -83,6 +91,14 @@ public class BoardController {
             @PageableDefault(size = 3) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService.searchBoardByDate(date, pageable));
+    }
+
+    @GetMapping("/time")
+    public ResponseEntity<Page<BoardSearchResponse>> boardSearchByTime(
+            @RequestParam String time,
+            @PageableDefault(size = 3) Pageable pageable
+    ) {
+        return ResponseEntity.ok(boardService.searchBoardByTime(time, pageable));
     }
 
     @GetMapping("/region")

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardCreateRequest.java
@@ -22,6 +22,8 @@ public class BoardCreateRequest {
 
     private String date;
 
+    private String time;
+
     private String wineName;
 
     private Integer headcount;
@@ -35,6 +37,7 @@ public class BoardCreateRequest {
                 .name(name)
                 .creator(member.getNickname())
                 .date(date)
+                .time(time)
                 .wineName(wineName)
                 .headcount(headcount)
                 .contents(contents)

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardUpdateRequest.java
@@ -15,6 +15,7 @@ public class BoardUpdateRequest {
     private String name;
     private String creator;
     private String date;
+    private String time;
     private String wineName;
     private Integer headcount;
     private String contents;

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchDetailResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchDetailResponse.java
@@ -10,11 +10,10 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class BoardCreateResponse {
-
-    private Long memberId;
-    private Long winebarId;
-    private String name;
+public class BoardSearchDetailResponse {
+    private String name;        // board 제목
+    private String winebarName;
+    private String winebarAddress;
     private String creator;
     private String date;
     private String time;
@@ -22,11 +21,11 @@ public class BoardCreateResponse {
     private Integer headcount;
     private String contents;
 
-    public static BoardCreateResponse fromEntity(Board board) {
-        return BoardCreateResponse.builder()
-                .memberId(board.getMember().getId())
-                .winebarId(board.getWinebar().getId())
+    public static BoardSearchDetailResponse fromEntity(Board board) {
+        return BoardSearchDetailResponse.builder()
                 .name(board.getName())
+                .winebarName(board.getWinebar().getName())
+                .winebarAddress(board.getWinebar().getAddress())
                 .creator(board.getCreator())
                 .date(board.getDate())
                 .time(board.getTime())

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
@@ -16,6 +16,7 @@ public class BoardSearchResponse {
     private String winebarName;
     private String creator;
     private String date;
+    private String time;
     private String wineName;
     private Integer headcount;
     private String contents;
@@ -26,6 +27,7 @@ public class BoardSearchResponse {
                 .winebarName(board.getWinebar().getName())
                 .creator(board.getCreator())
                 .date(board.getDate())
+                .time(board.getTime())
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())

--- a/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
@@ -38,6 +38,7 @@ public class Board extends BaseEntity {
     private String name;
     private String creator;
     private String date;
+    private String time;
     private String wineName;
     private Integer headcount;
     private String contents;

--- a/src/main/java/com/be/friendy/warendy/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/repository/BoardRepository.java
@@ -5,6 +5,7 @@ import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,6 +13,7 @@ import java.util.Optional;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
+    @NonNull
     Optional<Board> findById(Long id);
 
     Page<Board> findByName(String boardName, Pageable pageable);
@@ -23,6 +25,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findByCreator(String creator, Pageable pageable);
 
     Page<Board> findByDate(String date, Pageable pageable);
+
+    Page<Board> findByTime(String time, Pageable pageable);
 
     boolean existsByName(String name);
 }

--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -3,6 +3,7 @@ package com.be.friendy.warendy.domain.board.service;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.repository.BoardRepository;
@@ -61,6 +62,12 @@ public class BoardService {
                 .map(BoardSearchResponse::fromEntity);
     }
 
+    public BoardSearchDetailResponse searchBoardDetail(Long boardId) {
+        return boardRepository.findById(boardId)
+                .map(BoardSearchDetailResponse::fromEntity)
+                .orElseThrow(() -> new RuntimeException("the board does not exist"));
+    }
+
     public Page<BoardSearchResponse> searchBoardByBoardName(
             String name, Pageable pageable
     ) {
@@ -104,6 +111,13 @@ public class BoardService {
     ) {
         String dateToStr = String.valueOf(date);
         return boardRepository.findByDate(dateToStr, pageable)
+                .map(BoardSearchResponse::fromEntity);
+    }
+
+    public Page<BoardSearchResponse> searchBoardByTime(
+            String time, Pageable pageable
+    ) {
+        return boardRepository.findByTime(time, pageable)
                 .map(BoardSearchResponse::fromEntity);
     }
 

--- a/src/main/java/com/be/friendy/warendy/domain/member/entity/Member.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/entity/Member.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 // delete 요청이 들어올때 db에 삭제되지 않고 deleted_at 컬럼에 삭제요청 시간으로 업데이트 된다.
 @Where(clause = "deleted_at is NULL")
 @Entity(name = "MEMBER")
-public class Member extends BaseEntity implements UserDetails {
+public class Member extends BaseEntity {
 
     @Id // 엔티티 내부에서 아이디임을 선언
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 시퀀스 전략 선언
@@ -83,31 +83,6 @@ public class Member extends BaseEntity implements UserDetails {
         authorities.add(simpleAuthority);
 
         return authorities;
-    }
-
-    @Override
-    public String getUsername() {
-        return null;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return false;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return false;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return false;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return false;
     }
 
 }

--- a/src/main/java/com/be/friendy/warendy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.be.friendy.warendy.domain.member.repository;
 
 import com.be.friendy.warendy.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,6 +13,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByNickname(String nickname);
 
+    @NonNull
     Optional<Member> findById(Long memberId);
 
     boolean existsByEmail(String email);

--- a/src/test/java/com/be/friendy/warendy/WarendyBeApplicationTests.java
+++ b/src/test/java/com/be/friendy/warendy/WarendyBeApplicationTests.java
@@ -1,0 +1,11 @@
+package com.be.friendy.warendy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class WarendyBeApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -7,6 +7,7 @@ import com.be.friendy.warendy.config.security.SecurityConfig;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.service.BoardService;
@@ -73,6 +74,7 @@ class BoardControllerTest {
                         .name("board name")
                         .creator("nick name")
                         .date("2010-1-1")
+                        .time("7AM")
                         .wineName("wine name")
                         .headcount(4)
                         .contents("hello world!")
@@ -88,6 +90,7 @@ class BoardControllerTest {
                                         .name("board name1")
                                         .creator("nick name1")
                                         .date("2010-1-11")
+                                        .time("7AM")
                                         .wineName("wine name1")
                                         .headcount(4)
                                         .contents("hello world!1")
@@ -126,6 +129,7 @@ class BoardControllerTest {
                         .name("board name")
                         .creator("nick name")
                         .date("2010-1-1")
+                        .time("7AM")
                         .wineName("wine name")
                         .headcount(4)
                         .contents("hello world!")
@@ -143,6 +147,7 @@ class BoardControllerTest {
                                         .name("board name1")
                                         .creator("nick name1")
                                         .date("2010-1-11")
+                                        .time("7AM")
                                         .wineName("wine name1")
                                         .headcount(4)
                                         .contents("hello world!1")
@@ -161,6 +166,31 @@ class BoardControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Search Detail! - board")
+    void successSearchBoardDetail() throws Exception {
+        //given
+        given(boardService.searchBoardDetail(anyLong()))
+                .willReturn(BoardSearchDetailResponse.builder()
+                        .name("A")
+                        .winebarName("B")
+                        .winebarAddress("C")
+                        .creator("D")
+                        .date("2020-1-1")
+                        .time("7PM")
+                        .wineName("E")
+                        .headcount(3)
+                        .contents("F")
+                        .build());
+        //when
+        //then
+        mockMvc.perform(get("/boards/{board-id}/detail", 1L))
+                .andDo(print())
+                .andExpect(jsonPath("$.name").value("A"))
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
     @DisplayName("success Search with a Creator! - board")
     void successSearchBoardByCreator() throws Exception {
         //given
@@ -171,6 +201,7 @@ class BoardControllerTest {
                                 .name("board")
                                 .creator("Hong")
                                 .date("2000-1-1")
+                                .time("7AM")
                                 .wineName("wine")
                                 .headcount(4)
                                 .contents("content yo")
@@ -180,6 +211,7 @@ class BoardControllerTest {
                                 .name("board2")
                                 .creator("Hong")
                                 .date("2000-1-12")
+                                .time("10AM")
                                 .wineName("wine2")
                                 .headcount(5)
                                 .contents("content yo2")
@@ -189,6 +221,7 @@ class BoardControllerTest {
                                 .name("board3")
                                 .creator("Hong")
                                 .date("2000-1-13")
+                                .time("8AM")
                                 .wineName("wine3")
                                 .headcount(6)
                                 .contents("content yo3")
@@ -234,7 +267,7 @@ class BoardControllerTest {
         //when
         //then
         mockMvc.perform(get("/boards/wine-name?wineName={}", "AAA")
-                .contentType(MediaType.APPLICATION_JSON).with(csrf()))
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
@@ -3,6 +3,7 @@ package com.be.friendy.warendy.domain.board.service;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.repository.BoardRepository;
@@ -85,6 +86,7 @@ class BoardServiceTest {
                         .name("A")
                         .creator("A")
                         .date("2010-1-13")
+                        .time("7AM")
                         .wineName("123")
                         .headcount(4)
                         .contents("123")
@@ -95,6 +97,7 @@ class BoardServiceTest {
                 .name("board name")
                 .creator("nick name")
                 .date("2010-1-1")
+                .time("7AM")
                 .wineName("wine name")
                 .headcount(6)
                 .contents("hello world!")
@@ -106,6 +109,43 @@ class BoardServiceTest {
         assertEquals(1L, createResponse.getWinebarId());
         assertEquals("A", createResponse.getCreator());
         assertEquals(4, createResponse.getHeadcount());
+    }
+
+    @Test
+    void successSearchBoardDetail() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(1L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        Board board =  Board.builder()
+                .id(1L).member(member1).winebar(winebar1).name("A")
+                .creator("A").date("2010-1-13").time("7AM")
+                .wineName("123").headcount(4).contents("123")
+                .build();
+        given(boardRepository.findById(board.getId()))
+                .willReturn(Optional.of(board));
+        //when
+        BoardSearchDetailResponse boardDetailResponse
+                = boardService.searchBoardDetail(1L);
+        //then
+        assertEquals("AA", boardDetailResponse.getWinebarName());
+
     }
 
     @Test
@@ -133,16 +173,19 @@ class BoardServiceTest {
                 .build();
         List<Board> boardList = Arrays.asList(
                 Board.builder()
-                        .id(1L).member(member1).winebar(winebar1).name("A").creator("A")
-                        .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                        .id(1L).member(member1).winebar(winebar1).name("A")
+                        .creator("A").date("2010-1-13").time("7AM")
+                        .wineName("123").headcount(4).contents("123")
                         .build(),
                 Board.builder()
-                        .id(1L).member(member1).winebar(winebar1).name("Ab").creator("Ab")
-                        .date("2010-1-13b").wineName("123b").headcount(45).contents("123b")
+                        .id(1L).member(member1).winebar(winebar1).name("Ab")
+                        .creator("Ab").date("2010-1-13b").time("7AM")
+                        .wineName("123b").headcount(45).contents("123b")
                         .build(),
                 Board.builder()
-                        .id(1L).member(member1).winebar(winebar1).name("Ac").creator("Ac")
-                        .date("2010-1-13c").wineName("123c").headcount(46).contents("123c")
+                        .id(1L).member(member1).winebar(winebar1).name("Ac")
+                        .creator("Ac").date("2010-1-13c").time("7AM")
+                        .wineName("123c").headcount(46).contents("123c")
                         .build()
         );
         given(memberRepository.findByNickname(anyString()))
@@ -187,6 +230,7 @@ class BoardServiceTest {
         Board targetBoard = Board.builder()
                 .id(1L).member(member1).winebar(winebar1).name("A").creator("A")
                 .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                .time("7AM")
                 .build();
         given(boardRepository.save(any())).willReturn(targetBoard);
         given(boardRepository.findById(anyLong()))
@@ -198,6 +242,7 @@ class BoardServiceTest {
                 .name("name1")
                 .creator("creator!")
                 .date("2020-1-1")
+                .time("7AM")
                 .wineName("AAA")
                 .headcount(5)
                 .contents("empty at all")
@@ -236,6 +281,7 @@ class BoardServiceTest {
         Board targetBoard = Board.builder()
                 .id(1L).member(member1).winebar(winebar1).name("A").creator("A")
                 .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                .time("7AM")
                 .build();
         given(boardRepository.findById(anyLong()))
                 .willReturn(Optional.of(targetBoard));
@@ -260,6 +306,7 @@ class BoardServiceTest {
                                 .name("name")
                                 .creator("creator")
                                 .date("2020-1-1")
+                                .time("7AM")
                                 .wineName("winename")
                                 .headcount(1)
                                 .contents("cont")
@@ -281,12 +328,24 @@ class BoardServiceTest {
                                 .name("name")
                                 .creator("creator")
                                 .date("2020-1-1")
+                                .time("7AM")
                                 .wineName("winename")
                                 .headcount(1)
                                 .contents("cont")
                                 .build()));
         //then
         assertEquals("winebar does not exist",exception.getMessage());
+    }
+
+    @Test
+    void failedSearchBoardDetailNotFoundBoard() {
+        //given
+        given(boardRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.searchBoardDetail(1L));
+        //then
+        assertEquals("the board does not exist",exception.getMessage());
     }
 
     @Test
@@ -328,6 +387,7 @@ class BoardServiceTest {
                                 .name("name")
                                 .creator("creator")
                                 .date("2020-1-1")
+                                .time("7AM")
                                 .wineName("winename")
                                 .headcount(1)
                                 .contents("cont")


### PR DESCRIPTION
### 동행 게시글 단 건 상세 조회 기능 추가
게시글 상세 보기 기능 구현 코드.
-  #### CHANGES
    -  단 건 게시글 조회 controller, service  단에 추가.
    -  responseDTO 추가.
    -  테스트 코드 추가.
-  #### 상세내용
    -  searchboardDetail, service
    -  boardSearchDetail, controller
    -  BoardSearchDetailResponse, responseDTO
        -  name, winebarName, winebarAddress, creator, date, time, wineName, headcount, contents.
    -  성공, 실패 사례 테스트 코드.
        - 실패 : 해당 게시글 존재 X.

### Board Entity에 Time 컬럼 추가
만남 시간을 저장할 수 있는 컬럼.
-  #### CHANGES
    - String time 추가
    - 시간으로 게시글 조회 하는 기능 추가.
    - 성공 사례 테스트 코드 추가. 