### PR TITLE
내 주변 와인바 조회 기능 추가

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/winebar/controller/WinebarController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/controller/WinebarController.java
@@ -27,4 +27,11 @@ public class WinebarController {
         return ResponseEntity.ok(wineBarService.searchWinebar(lat, lnt));
     }
 
+    @GetMapping("/winebars/around")
+    public ResponseEntity<List<WinebarSearchResponse>> aroundWineBarSearch (
+            @RequestParam Double lat, @RequestParam Double lnt
+    ) {
+        return ResponseEntity.ok(wineBarService.searchWinebarAround(lat, lnt));
+    }
+
 }

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/repository/WinebarRepository.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/repository/WinebarRepository.java
@@ -2,6 +2,7 @@ package com.be.friendy.warendy.domain.winebar.repository;
 
 import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,5 +14,12 @@ public interface WinebarRepository extends JpaRepository<Winebar, Long> {
     Optional<Winebar> findByName(String name);
 
     Optional<Winebar> findByLatAndLnt(Double lat, Double lnt);
+
+    String distance = "ROUND((6371 * acos(cos(radians(3)) * cos(radians(lat)) " +
+            "* cos(radians(lnt) - radians(3)) + sin(radians(3)) " +
+            "* sin(radians(lat))))) AS distance ";
+    @Query(value = "SELECT *, " + distance
+            + "FROM warendy.winebar ORDER BY distance LIMIT 20", nativeQuery = true)
+    List<Winebar> findByDistance(Double lat, Double lnt);
 
 }

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/service/WineBarService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/service/WineBarService.java
@@ -6,6 +6,8 @@ import com.be.friendy.warendy.domain.winebar.repository.WinebarRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @AllArgsConstructor
 public class WineBarService {
@@ -18,4 +20,11 @@ public class WineBarService {
 
     }
 
+    public List<WinebarSearchResponse> searchWinebarAround(Double lat, Double lnt) {
+
+        List<WinebarSearchResponse> winebarList =
+                winebarRepository.findByDistance(lat, lnt).stream()
+                        .map(WinebarSearchResponse::fromEntity).toList();
+        return winebarList;
+    }
 }

--- a/src/test/java/com/be/friendy/warendy/domain/winebar/controller/WinebarControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/winebar/controller/WinebarControllerTest.java
@@ -1,0 +1,89 @@
+package com.be.friendy.warendy.domain.winebar.controller;
+
+import com.be.friendy.warendy.config.jwt.TokenProvider;
+import com.be.friendy.warendy.config.jwt.filter.JwtAuthenticationFilter;
+import com.be.friendy.warendy.domain.winebar.dto.response.WinebarSearchResponse;
+import com.be.friendy.warendy.domain.winebar.service.WineBarService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+
+@WebMvcTest(value = WinebarController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                        classes = TokenProvider.class)
+        }
+)
+class WinebarControllerTest {
+
+    @MockBean
+    private WineBarService wineBarService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void successWinebarAroundSearch() throws Exception {
+        //given
+
+        List<WinebarSearchResponse> responses =
+                Arrays.asList(
+                        WinebarSearchResponse.builder()
+                                .name("Hong")
+                                .picture("Asdfasdf")
+                                .address("ASD")
+                                .lat(1.1)
+                                .lnt(1.1)
+                                .rating(1.1)
+                                .reviews(1)
+                                .build(),
+                        WinebarSearchResponse.builder()
+                                .name("Hong1")
+                                .picture("Asdfasdf")
+                                .address("A")
+                                .lat(1.13)
+                                .lnt(1.13)
+                                .rating(1.1)
+                                .reviews(1)
+                                .build(),
+                        WinebarSearchResponse.builder()
+                                .name("Hong2")
+                                .picture("Asdfasdf")
+                                .address("ASDFasd")
+                                .lat(1.1)
+                                .lnt(1.1)
+                                .rating(1.1)
+                                .reviews(1)
+                                .build()
+                );
+
+        given(wineBarService.searchWinebarAround(anyDouble(), anyDouble()))
+                .willReturn(responses);
+        //when
+        //then
+        mockMvc.perform(get("/winebars/around")
+                        .param("lat", String.valueOf(12.3))
+                        .param("lnt", String.valueOf(12.3)))
+                .andDo(print())
+                .andExpect(jsonPath("$.[0].name").value("Hong"))
+        ;
+    }
+}

--- a/src/test/java/com/be/friendy/warendy/domain/winebar/service/WineBarServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/winebar/service/WineBarServiceTest.java
@@ -1,0 +1,74 @@
+package com.be.friendy.warendy.domain.winebar.service;
+
+import com.be.friendy.warendy.domain.winebar.dto.response.WinebarSearchResponse;
+import com.be.friendy.warendy.domain.winebar.entity.Winebar;
+import com.be.friendy.warendy.domain.winebar.repository.WinebarRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WineBarServiceTest {
+    @Mock
+    private WinebarRepository winebarRepository;
+
+    @InjectMocks
+    private WineBarService wineBarService;
+
+    @Test
+    void successSearchWinebarAround() {
+        //given
+        List<Winebar> winebarList =
+                Arrays.asList(
+                        Winebar.builder()
+                                .id(2L)
+                                .name("Hong")
+                                .picture("Asdfasdf")
+                                .address("ASD")
+                                .lat(1.1)
+                                .lnt(1.1)
+                                .rating(1.1)
+                                .reviews(1)
+                                .build(),
+                        Winebar.builder()
+                                .id(1L)
+                                .name("Hong1")
+                                .picture("Asdfasdf")
+                                .address("A")
+                                .lat(1.13)
+                                .lnt(1.13)
+                                .rating(1.1)
+                                .reviews(1)
+                                .build(),
+                        Winebar.builder()
+                                .id(3L)
+                                .name("Hong2")
+                                .picture("Asdfasdf")
+                                .address("ASDFasd")
+                                .lat(1.1)
+                                .lnt(1.1)
+                                .rating(1.1)
+                                .reviews(1)
+                                .build()
+                );
+
+        given(winebarRepository.findByDistance(anyDouble(), anyDouble()))
+                .willReturn(winebarList);
+        //when
+        List<WinebarSearchResponse> responses = wineBarService
+                .searchWinebarAround(1.1, 1.1);
+        //then
+        assertEquals("Hong", responses.get(0).getName());
+    }
+
+
+}


### PR DESCRIPTION
#### 와인바 조회 기능 추가
내 중심 근처 와인바 조회(최대 20개) 할 수 있는 기능.

#### -  changes
 내 주변 radian(3) 만큼 거리 주변 최대 20개 와인바 조회.
 통신 수단 - GET , url - /winebars/around?lat={Double}&lnt={Double}
 
 #### - 상세내용
    -  거리 계산 식 : String distance = "ROUND((6371 * acos(cos(radians(3)) * cos(radians(lat)) " +
            "* cos(radians(lnt) - radians(3)) + sin(radians(3)) " +
            "* sin(radians(lat))))) AS distance ";
    - controller : aroundWineBarSearch (@RequestParam Double lat, @RequestParam Double lnt)
    - service : searchWinebarAround(Double lat, Double lnt)
    - resposeDTO(WinebarSearchResponse)
    - 리턴 값 : List<WinebarSearchResponse>
    - MocMvc 이용 테스트 코드 구현.
 