### PR TITLE
동행 게시글 기능 권한 설정 변경.

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.be.friendy.warendy.domain.board.controller;
 
 
+import com.be.friendy.warendy.config.jwt.TokenProvider;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
@@ -25,13 +26,16 @@ import java.time.LocalDate;
 @RequestMapping("/boards")
 public class BoardController {
     private final BoardService boardService;
+    private final TokenProvider tokenProvider;
 
     @PostMapping("/winebars/{winebar-id}")
     public ResponseEntity<BoardCreateResponse> boardCreate(
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable(value = "winebar-id") Long winebarId,
             @RequestBody BoardCreateRequest request
     ) {
-        return ResponseEntity.ok(boardService.creatBoard(winebarId, request));
+        String email = tokenProvider.getEmailFromToken(authorizationHeader);
+        return ResponseEntity.ok(boardService.creatBoard(email, winebarId, request));
     }
 
     @GetMapping("")
@@ -109,18 +113,22 @@ public class BoardController {
 
     @PutMapping("/{board-id}")
     public ResponseEntity<Board> boardUpdate(
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable(value = "board-id") Long boardId,
             @RequestBody BoardUpdateRequest boardUpdateRequest
     ) {
+        String email = tokenProvider.getEmailFromToken(authorizationHeader);
         return ResponseEntity.ok(
-                boardService.updateBoard(boardId, boardUpdateRequest));
+                boardService.updateBoard(email, boardId, boardUpdateRequest));
     }
 
     @DeleteMapping("/{board-id}")
     public ResponseEntity<String> boardDelete(
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable(value = "board-id") Long boardId
     ) {
-        boardService.deleteBoard(boardId);
+        String email = tokenProvider.getEmailFromToken(authorizationHeader);
+        boardService.deleteBoard(email, boardId);
         return ResponseEntity.ok("board is deleted!");
     }
 

--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -30,7 +30,7 @@ public class BoardService {
     private final WineRepository wineRepository;
 
     public BoardCreateResponse creatBoard(
-            Long winebarId, BoardCreateRequest createRequest) {
+            String email, Long winebarId, BoardCreateRequest createRequest) {
         boolean exists = boardRepository.existsByName(createRequest.getName());
         if (exists) {
             throw new RuntimeException("already exists");
@@ -40,12 +40,19 @@ public class BoardService {
                 .findById(winebarId)
                 .orElseThrow(() -> new RuntimeException("winebar does not exist"));
 
-        Member member = memberRepository.findById(createRequest.getMemberId())
+        Member memberById = memberRepository.findById(createRequest.getMemberId())
                 .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        Member memberByEmail = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        if (!memberById.equals(memberByEmail)) {
+            throw new RuntimeException("check the user information");
+        }
 
         return BoardCreateResponse.fromEntity(boardRepository.save(
                 Board.builder()
-                        .member(member)
+                        .member(memberById)
                         .winebar(winebar)
                         .name(createRequest.getName())
                         .creator(createRequest.getCreator())
@@ -121,17 +128,40 @@ public class BoardService {
                 .map(BoardSearchResponse::fromEntity);
     }
 
-    public Board updateBoard(Long boardId, BoardUpdateRequest request) {
+    public Board updateBoard(String email, Long boardId, BoardUpdateRequest request) {
+
         Board nowBoard = boardRepository.findById(boardId)
                 .orElseThrow(() -> new RuntimeException("the board does not exist"));
-        ;
         nowBoard.updateBoardInfo(request);
+
+        Member memberById = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        Member memberByEmail = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        if (!memberById.equals(memberByEmail)) {
+            throw new RuntimeException("check the user information");
+        }
+
         return boardRepository.save(nowBoard);
     }
 
-    public void deleteBoard(Long boardId) {
+    public void deleteBoard(String email, Long boardId) {
+
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new RuntimeException("the board does not exist"));
+
+        Member memberById = memberRepository.findById(board.getMember().getId())
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        Member memberByEmail = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+        if (!memberById.equals(memberByEmail)) {
+            throw new RuntimeException("check the user information");
+        }
+
         boardRepository.save(board); // test 코드에서 확인 위한
         boardRepository.delete(board);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  jackson:
+    serialization:
+      fail-on-empty-beans: false
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## 동행 게시글 기능 권한 설정
조회 기능은 모두 접근이 가능하고, 나머지 작성, 수정, 삭제 기능은 작성자만 가능하게 구현.
### changes
-  controller : boardCreate, boardUpdate, boardDelete에 @RequestHeader("Authorization") String authorizationHeader 받도록 변경.
-  service : creatBoard, UpdateBoard, DeleteBoard에 Email 받도록 변경.
    -  받은 토큰에서 Email 추출.
-  테스트 코드 토큰 받을 수 있게 변경.
    -  성공, 실패 케이스 변경사항 적용.
    -  추가된 조건 성공, 실패 케이스 추가.