### PR TITLE
동행 게시글 refactoring(responseDTO, winebarId 검색 추가, url 변경, 본인 인증 수정.)

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -7,7 +7,7 @@ import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
-import com.be.friendy.warendy.domain.board.entity.Board;
+import com.be.friendy.warendy.domain.board.dto.response.BoardUpdateResponse;
 import com.be.friendy.warendy.domain.board.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,10 +28,10 @@ public class BoardController {
     private final BoardService boardService;
     private final TokenProvider tokenProvider;
 
-    @PostMapping("/winebars/{winebar-id}")
+    @PostMapping("/winebars")
     public ResponseEntity<BoardCreateResponse> boardCreate(
             @RequestHeader("Authorization") String authorizationHeader,
-            @PathVariable(value = "winebar-id") Long winebarId,
+            @RequestParam(value = "winebar-id") Long winebarId,
             @RequestBody BoardCreateRequest request
     ) {
         String email = tokenProvider.getEmailFromToken(authorizationHeader);
@@ -40,7 +40,7 @@ public class BoardController {
 
     @GetMapping("/all")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearch(
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService.searchBoard(pageable));
     }
@@ -55,7 +55,7 @@ public class BoardController {
     @GetMapping("")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchMyBoard(
             @RequestHeader("Authorization") String authorizationHeader,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         String email = tokenProvider.getEmailFromToken(authorizationHeader);
         return ResponseEntity.ok(boardService.searchMyBoardByEmail(email, pageable));
@@ -77,6 +77,15 @@ public class BoardController {
     ) {
         return ResponseEntity.ok(boardService
                 .searchBoardByWineName(wineName, pageable));
+    }
+
+    @GetMapping("/winebar-id")
+    public ResponseEntity<Page<BoardSearchResponse>> boardSearchByWinebarId(
+            @RequestParam(value = "winebar-id") Long winebarId,
+            @PageableDefault(size = 3) Pageable pageable
+    ) {
+        return ResponseEntity.ok(boardService
+                .searchBoardByWinebarId(winebarId, pageable));
     }
 
     @GetMapping("/winebar-name")
@@ -121,7 +130,7 @@ public class BoardController {
     }
 
     @PutMapping("/{board-id}")
-    public ResponseEntity<Board> boardUpdate(
+    public ResponseEntity<BoardUpdateResponse> boardUpdate(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable(value = "board-id") Long boardId,
             @RequestBody BoardUpdateRequest boardUpdateRequest

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardUpdateResponse.java
@@ -1,0 +1,34 @@
+package com.be.friendy.warendy.domain.board.dto.response;
+
+import com.be.friendy.warendy.domain.board.entity.Board;
+import lombok.*;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardUpdateResponse {
+    private String name;
+    private String nickname;
+    private String winebarName;
+    private String date;
+    private String time;
+    private String wineName;
+    private Integer headcount;
+    private String contents;
+
+    public static BoardUpdateResponse fromEntity(Board board) {
+        return BoardUpdateResponse.builder()
+                .name(board.getName())
+                .nickname(board.getNickname())
+                .winebarName(board.getWinebar().getName())
+                .date(board.getDate())
+                .time(board.getTime())
+                .wineName(board.getWineName())
+                .headcount(board.getHeadcount())
+                .contents(board.getContents())
+                .build();
+    }
+}

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -7,6 +7,7 @@ import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
 import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
 import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
+import com.be.friendy.warendy.domain.board.dto.response.BoardUpdateResponse;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.service.BoardService;
 import com.be.friendy.warendy.domain.member.entity.Member;
@@ -78,7 +79,7 @@ class BoardControllerTest {
                         .build());
         //when
         //then
-        mockMvc.perform(post("/boards/winebars/1")
+        mockMvc.perform(post("/boards/winebars?winebar-id=1")
                         .contentType(MediaType.APPLICATION_JSON).with(csrf())
                         .content(objectMapper
                                 .writeValueAsString(BoardCreateRequest
@@ -114,7 +115,7 @@ class BoardControllerTest {
         given(tokenProvider.getEmailFromToken(any()))
                 .willReturn(email);
         given(boardService.updateBoard(anyString(), anyLong(), any()))
-                .willReturn(Board.builder().id(1L)
+                .willReturn(BoardUpdateResponse.fromEntity(Board.builder().id(1L)
                         .member(Member.builder().id(1L)
                                 .email("asdf@gmail.com")
                                 .password("asdfasdfasdf")
@@ -135,7 +136,7 @@ class BoardControllerTest {
                         .wineName("wine name")
                         .headcount(4)
                         .contents("hello world!")
-                        .build());
+                        .build()));
 
         //when
         //then
@@ -158,9 +159,9 @@ class BoardControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(
-                        jsonPath("$.member.id").value(1))
+                        jsonPath("$.nickname").value("nick name"))
                 .andExpect(
-                        jsonPath("$.winebar.id").value(1))
+                        jsonPath("$.winebarName").value("AAA"))
                 .andExpect(
                         jsonPath("$.name").value("board name"))
                 .andExpect(
@@ -243,6 +244,58 @@ class BoardControllerTest {
         mockMvc.perform(get("/boards?page=0")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
                 )
+                .andDo(print())
+                .andExpect(jsonPath("$.content[0].nickname")
+                        .value("Hong"))
+                .andExpect(jsonPath("$.content[1].nickname")
+                        .value("Hong"))
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void successSearchBoardByWinebarId() throws Exception {
+        //given
+        List<BoardSearchResponse> boardSearchResponses =
+                Arrays.asList(
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar")
+                                .name("board")
+                                .nickname("Hong")
+                                .date("2000-1-1")
+                                .time("7AM")
+                                .wineName("wine")
+                                .headcount(4)
+                                .contents("content yo")
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar2")
+                                .name("board2")
+                                .nickname("Hong")
+                                .date("2000-1-12")
+                                .time("10AM")
+                                .wineName("wine2")
+                                .headcount(5)
+                                .contents("content yo2")
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar3")
+                                .name("board3")
+                                .nickname("Hong")
+                                .date("2000-1-13")
+                                .time("8AM")
+                                .wineName("wine3")
+                                .headcount(6)
+                                .contents("content yo3")
+                                .build()
+                );
+        PageImpl<BoardSearchResponse> boardSearchResponsePage =
+                new PageImpl<>(boardSearchResponses);
+        given(boardService.searchBoardByWinebarId(anyLong(), any()))
+                .willReturn(boardSearchResponsePage);
+        //when
+        //then
+        mockMvc.perform(get("/boards/winebar-id?winebar-id=1&page=0"))
                 .andDo(print())
                 .andExpect(jsonPath("$.content[0].nickname")
                         .value("Hong"))
@@ -344,7 +397,7 @@ class BoardControllerTest {
                 .willThrow(new RuntimeException("check the user information"));
         //when
         //then
-        mockMvc.perform(post("/boards/winebars/1")
+        mockMvc.perform(post("/boards/winebars?winebar-id=1")
                         .contentType(MediaType.APPLICATION_JSON).with(csrf())
                         .content(objectMapper
                                 .writeValueAsString(BoardCreateRequest
@@ -401,7 +454,7 @@ class BoardControllerTest {
                 .willThrow(new RuntimeException("user does not exist"));
         //when
         //then
-        mockMvc.perform(post("/boards/winebars/1")
+        mockMvc.perform(post("/boards/winebars?winebar-id=1")
                         .contentType(MediaType.APPLICATION_JSON).with(csrf())
                         .content(objectMapper
                                 .writeValueAsString(BoardCreateRequest


### PR DESCRIPTION
### responseDTO 추가
board update 시 순환참조로 인해 발생하는 에러 예방 위해 반환 타입 변경
-  ####changes
    -  기존 : Board(Entity)
    -  변경 후 :  BoardUpdateResponse(DTO)

### 새로운 보드 검색 기준 추가.
winebar 테이블 참조하고 있기 때문에, winebar Id 로 검색 가능
-  #### changes
    -  url : get - /board/winebar?winbar-id={Long}, RequestParm으로 winebarId 넘김.
    -  controller : boardSearchByWinebarId(winebarId, pageable)
    -  service : searchBoardByWinebarId(winebarId, pageable)
    -  테스트 코드 추가.

### controller url 변경
 board와 관련 없는 pathVariable requestParam으로 변경.
-  #### 적용 함수
    -  boardCreate

### 본인 검증 방법 수정.
의미없는 비교 제거 및 수정.
-  #### chages
    -  기존 : request의 memberId와 토큰의 email을 가지고 각 멤버를 검색 및 비교
    -  변경 후 : boardId로 검색한 board에서 뽑은 memberId 활용. 
