### PR TITLE
feature/#35-winebar

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/winebar/dto/response/WinebarSearchResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/dto/response/WinebarSearchResponse.java
@@ -1,8 +1,11 @@
 package com.be.friendy.warendy.domain.winebar.dto.response;
 
 
+import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
 import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import lombok.*;
+
+import java.util.List;
 
 @Setter
 @Getter
@@ -26,6 +29,8 @@ public class WinebarSearchResponse {
 
     private Integer reviews;
 
+    private List<BoardSearchResponse> boardList;
+
     public static WinebarSearchResponse fromEntity(Winebar winebar) {
         return WinebarSearchResponse.builder()
                 .name(winebar.getName())
@@ -35,6 +40,9 @@ public class WinebarSearchResponse {
                 .lat(winebar.getLat())
                 .rating(winebar.getRating())
                 .reviews(winebar.getReviews())
+                .boardList(winebar.getBoardList()
+                        .stream().map(BoardSearchResponse::fromEntity)
+                        .toList())
                 .build();
     }
 

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/entity/Winebar.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/entity/Winebar.java
@@ -1,10 +1,13 @@
 package com.be.friendy.warendy.domain.winebar.entity;
 
 
+import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
+
+import java.util.List;
 
 @Getter
 @ToString
@@ -35,4 +38,6 @@ public class Winebar extends BaseEntity {
 
     private Integer reviews;
 
+    @OneToMany(mappedBy = "winebar", fetch = FetchType.LAZY)
+    private List<Board> boardList;
 }

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/service/WineBarService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/service/WineBarService.java
@@ -15,16 +15,17 @@ public class WineBarService {
     WinebarRepository winebarRepository;
 
     public WinebarSearchResponse searchWinebar(Double lat, Double lnt) {
-        return WinebarSearchResponse.fromEntity(winebarRepository.findByLatAndLnt(lat, lnt)
-                .orElseThrow(() -> new RuntimeException("the winebar does not exists")));
+        return WinebarSearchResponse.fromEntity(
+                winebarRepository.findByLatAndLnt(lat, lnt).orElseThrow(
+                        () -> new RuntimeException("the winebar does not exists")));
 
     }
 
-    public List<WinebarSearchResponse> searchWinebarAround(Double lat, Double lnt) {
+    public List<WinebarSearchResponse> searchWinebarAround(
+            Double lat, Double lnt
+    ) {
 
-        List<WinebarSearchResponse> winebarList =
-                winebarRepository.findByDistance(lat, lnt).stream()
-                        .map(WinebarSearchResponse::fromEntity).toList();
-        return winebarList;
+        return winebarRepository.findByDistance(lat, lnt).stream()
+                .map(WinebarSearchResponse::fromEntity).toList();
     }
 }

--- a/src/test/java/com/be/friendy/warendy/domain/winebar/service/WineBarServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/winebar/service/WineBarServiceTest.java
@@ -1,5 +1,6 @@
 package com.be.friendy.warendy.domain.winebar.service;
 
+import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.winebar.dto.response.WinebarSearchResponse;
 import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import com.be.friendy.warendy.domain.winebar.repository.WinebarRepository;
@@ -9,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -27,6 +29,7 @@ class WineBarServiceTest {
     @Test
     void successSearchWinebarAround() {
         //given
+        List<Board> boardList = new ArrayList<>();
         List<Winebar> winebarList =
                 Arrays.asList(
                         Winebar.builder()
@@ -38,6 +41,7 @@ class WineBarServiceTest {
                                 .lnt(1.1)
                                 .rating(1.1)
                                 .reviews(1)
+                                .boardList(boardList)
                                 .build(),
                         Winebar.builder()
                                 .id(1L)
@@ -48,6 +52,7 @@ class WineBarServiceTest {
                                 .lnt(1.13)
                                 .rating(1.1)
                                 .reviews(1)
+                                .boardList(boardList)
                                 .build(),
                         Winebar.builder()
                                 .id(3L)
@@ -58,6 +63,7 @@ class WineBarServiceTest {
                                 .lnt(1.1)
                                 .rating(1.1)
                                 .reviews(1)
+                                .boardList(boardList)
                                 .build()
                 );
 


### PR DESCRIPTION
### 양방향 연관관계 설정
와인봐에서 한 와인봐와 관련있는 보드를 조회하기 위해 설정.
-  #### changes
     -  winebar Entity 에 @OneToMany(mappedBy = "winebar", fetch = FetchType.LAZY)
    private List<Board> boardList; 추가.
     -   WinebarSearchResponse (DTO) 에 private List<BoardSearchResponse> boardList; 컬럼 추가.
     - 

