### PR TITLE
동행 게시글 validation, transaction 설정, 동행 참여하기 기능 추.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-}
+// tasks.named('test') {
+//     useJUnitPlatform()
+// }
 
 jar {
     enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+//    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
@@ -43,9 +48,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 }
 
-//tasks.named('test') {
-//    useJUnitPlatform()
-//}
+tasks.named('test') {
+    useJUnitPlatform()
+}
 
 jar {
     enabled = false

--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -147,6 +147,15 @@ public class BoardController {
         return ResponseEntity.ok(boardService.participantInBoard(email, boardId));
     }
 
+    @PutMapping("/participants-out")
+    public ResponseEntity<BoardParticipantResponse> boardParticipantOut(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(value = "board-id") Long boardId
+    ) {
+        String email = tokenProvider.getEmailFromToken(authorizationHeader);
+        return ResponseEntity.ok(boardService.participantOutBoard(email, boardId));
+    }
+
 
     @DeleteMapping("/{board-id}")
     public ResponseEntity<String> boardDelete(

--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -4,11 +4,9 @@ package com.be.friendy.warendy.domain.board.controller;
 import com.be.friendy.warendy.config.jwt.TokenProvider;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
-import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardUpdateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.*;
 import com.be.friendy.warendy.domain.board.service.BoardService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -32,7 +30,7 @@ public class BoardController {
     public ResponseEntity<BoardCreateResponse> boardCreate(
             @RequestHeader("Authorization") String authorizationHeader,
             @RequestParam(value = "winebar-id") Long winebarId,
-            @RequestBody BoardCreateRequest request
+            @Valid @RequestBody BoardCreateRequest request
     ) {
         String email = tokenProvider.getEmailFromToken(authorizationHeader);
         return ResponseEntity.ok(boardService.creatBoard(email, winebarId, request));
@@ -139,6 +137,16 @@ public class BoardController {
         return ResponseEntity.ok(
                 boardService.updateBoard(email, boardId, boardUpdateRequest));
     }
+
+    @PutMapping("/participants")
+    public ResponseEntity<BoardParticipantResponse> boardParticipant(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(value = "board-id") Long boardId
+    ) {
+        String email = tokenProvider.getEmailFromToken(authorizationHeader);
+        return ResponseEntity.ok(boardService.participantInBoard(email, boardId));
+    }
+
 
     @DeleteMapping("/{board-id}")
     public ResponseEntity<String> boardDelete(

--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -131,7 +131,7 @@ public class BoardController {
     public ResponseEntity<BoardUpdateResponse> boardUpdate(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable(value = "board-id") Long boardId,
-            @RequestBody BoardUpdateRequest boardUpdateRequest
+            @Valid @RequestBody BoardUpdateRequest boardUpdateRequest
     ) {
         String email = tokenProvider.getEmailFromToken(authorizationHeader);
         return ResponseEntity.ok(

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardCreateResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardCreateResponse.java
@@ -4,6 +4,8 @@ package com.be.friendy.warendy.domain.board.dto.response;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import lombok.*;
 
+import java.util.Set;
+
 @Setter
 @Getter
 @ToString
@@ -21,6 +23,7 @@ public class BoardCreateResponse {
     private String wineName;
     private Integer headcount;
     private String contents;
+    private Set<String> participants;
 
     public static BoardCreateResponse fromEntity(Board board) {
         return BoardCreateResponse.builder()
@@ -33,6 +36,7 @@ public class BoardCreateResponse {
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())
+                .participants(board.getParticipants())
                 .build();
     }
 }

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardParticipantResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardParticipantResponse.java
@@ -4,6 +4,8 @@ package com.be.friendy.warendy.domain.board.dto.response;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import lombok.*;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Setter
@@ -12,11 +14,11 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class BoardSearchDetailResponse {
-    private String name;        // board 제목
-    private String winebarName;
-    private String winebarAddress;
+public class BoardParticipantResponse {
+
+    private String name;
     private String nickname;
+    private String winebarName;
     private String date;
     private String time;
     private String wineName;
@@ -24,12 +26,12 @@ public class BoardSearchDetailResponse {
     private String contents;
     private Set<String> participants;
 
-    public static BoardSearchDetailResponse fromEntity(Board board) {
-        return BoardSearchDetailResponse.builder()
+    public static BoardParticipantResponse fromEntity(Board board) {
+
+        return BoardParticipantResponse.builder()
                 .name(board.getName())
-                .winebarName(board.getWinebar().getName())
-                .winebarAddress(board.getWinebar().getAddress())
                 .nickname(board.getNickname())
+                .winebarName(board.getWinebar().getName())
                 .date(board.getDate())
                 .time(board.getTime())
                 .wineName(board.getWineName())

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
@@ -20,7 +20,7 @@ public class BoardSearchResponse {
     private String wineName;
     private Integer headcount;
     private String contents;
-
+    private Integer participants;
     public static BoardSearchResponse fromEntity(Board board) {
         return BoardSearchResponse.builder()
                 .name(board.getName())
@@ -31,6 +31,7 @@ public class BoardSearchResponse {
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())
+                .participants(board.getParticipants().size())
                 .build();
     }
 

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardUpdateResponse.java
@@ -3,6 +3,8 @@ package com.be.friendy.warendy.domain.board.dto.response;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import lombok.*;
 
+import java.util.Set;
+
 @Setter
 @Getter
 @ToString
@@ -18,6 +20,7 @@ public class BoardUpdateResponse {
     private String wineName;
     private Integer headcount;
     private String contents;
+    private Set<String> participants;
 
     public static BoardUpdateResponse fromEntity(Board board) {
         return BoardUpdateResponse.builder()
@@ -29,6 +32,7 @@ public class BoardUpdateResponse {
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())
+                .participants(board.getParticipants())
                 .build();
     }
 }

--- a/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
@@ -71,10 +71,10 @@ public class Board extends BaseEntity {
         participants = boardParticipants;
     }
 
-//    public void deleteBoardParticipant(Board board, String nickname) {
-//        Set<String> boardParticipants = board.getParticipants();
-//        boardParticipants.remove(nickname);
-//        participants = boardParticipants;
-//    }
+    public void deleteBoardParticipant(Board board, String nickname) {
+        Set<String> boardParticipants = board.getParticipants();
+        boardParticipants.remove(nickname);
+        participants = boardParticipants;
+    }
 
 }

--- a/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
@@ -6,9 +6,13 @@ import com.be.friendy.warendy.domain.common.BaseEntity;
 import com.be.friendy.warendy.domain.member.entity.Member;
 import com.be.friendy.warendy.domain.winebar.entity.Winebar;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Positive;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -35,13 +39,21 @@ public class Board extends BaseEntity {
     @JoinColumn(name = "WINEBAR_ID", nullable = false)
     private Winebar winebar;
 
+    @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private String nickname;
     private String date;
     private String time;
     private String wineName;
+
+    @Positive(message = "Headcount must be a positive number")
     private Integer headcount;
     private String contents;
+
+    @ElementCollection
+    private Set<String> participants = new HashSet<>();
 
     public void updateBoardInfo(BoardUpdateRequest request) {
         name = request.getName();
@@ -52,5 +64,17 @@ public class Board extends BaseEntity {
         headcount = request.getHeadcount();
         contents = request.getContents();
     }
+
+    public void insertBoardParticipant(Board board, String nickname) {
+        Set<String> boardParticipants = board.getParticipants();
+        boardParticipants.add(nickname);
+        participants = boardParticipants;
+    }
+
+//    public void deleteBoardParticipant(Board board, String nickname) {
+//        Set<String> boardParticipants = board.getParticipants();
+//        boardParticipants.remove(nickname);
+//        participants = boardParticipants;
+//    }
 
 }

--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -50,16 +50,16 @@ public class BoardService {
 
         return BoardCreateResponse.fromEntity(boardRepository.save(
                 Board.builder()
-                .member(memberByEmail)
-                .winebar(winebar)
-                .name(createRequest.getName())
-                .nickname(createRequest.getNickname())
-                .date(createRequest.getDate())
-                .wineName(createRequest.getWineName())
-                .headcount(createRequest.getHeadcount())
-                .contents(createRequest.getContents())
-                .participants(partySet)
-                .build()
+                        .member(memberByEmail)
+                        .winebar(winebar)
+                        .name(createRequest.getName())
+                        .nickname(createRequest.getNickname())
+                        .date(createRequest.getDate())
+                        .wineName(createRequest.getWineName())
+                        .headcount(createRequest.getHeadcount())
+                        .contents(createRequest.getContents())
+                        .participants(partySet)
+                        .build()
         ));
     }
 
@@ -177,6 +177,24 @@ public class BoardService {
         Member memberByEmail = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("user does not exist"));
         nowBoard.insertBoardParticipant(nowBoard, memberByEmail.getNickname());
+
+        boardRepository.save(nowBoard);
+        return BoardParticipantResponse.fromEntity(nowBoard);
+    }
+
+    public BoardParticipantResponse participantOutBoard(String email, Long boardId) {
+
+        Board nowBoard = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("the board does not exist"));
+        Member memberByEmail = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("user does not exist"));
+
+//        if(Objects.equals(nowBoard.getMember().getNickname()
+//                , memberByEmail.getNickname())) {
+//            throw new RuntimeException("자기 자신은 나갈 수 없습니다.");
+//        }
+
+        nowBoard.deleteBoardParticipant(nowBoard, memberByEmail.getNickname());
 
         boardRepository.save(nowBoard);
         return BoardParticipantResponse.fromEntity(nowBoard);

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -212,6 +212,40 @@ class BoardControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
+    void successParticipantOutBoard() throws Exception {
+        //given
+        String email = "AAA";
+        given(tokenProvider.getEmailFromToken(any()))
+                .willReturn(email);
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add("D");
+        given(boardService.participantOutBoard(anyString(), any()))
+                .willReturn(BoardParticipantResponse.builder()
+                        .name("A")
+                        .nickname("D")
+                        .winebarName("B")
+                        .date("2020-1-1")
+                        .time("7PM")
+                        .wineName("E")
+                        .headcount(3)
+                        .contents("F")
+                        .participants(partySet)
+                        .build());
+        //when
+        //then
+        mockMvc.perform(put("/boards/participants-out?board-id=1")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname").value("D"))
+                .andExpect(jsonPath("$.participants[0]").value("D"))
+                .andDo(print())
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
     @DisplayName("success Search Detail! - board")
     void successSearchBoardDetail() throws Exception {
         //given
@@ -544,6 +578,22 @@ class BoardControllerTest {
         //when
         //then
         mockMvc.perform(put("/boards/participants?board-id=1")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
+                )
+                .andExpect(status().isOk())
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void failedParticipantOutBoard() throws Exception {
+        //given
+        given(boardService.participantOutBoard(anyString(), anyLong()))
+                .willThrow(new RuntimeException("the board does not exist"));
+        //when
+        //then
+        mockMvc.perform(put("/boards/participants-out?board-id=1")
                         .contentType(MediaType.APPLICATION_JSON).with(csrf())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
                 )

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -4,10 +4,7 @@ import com.be.friendy.warendy.config.jwt.TokenProvider;
 import com.be.friendy.warendy.config.jwt.filter.JwtAuthenticationFilter;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
-import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardUpdateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.*;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.service.BoardService;
 import com.be.friendy.warendy.domain.member.entity.Member;
@@ -28,6 +25,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -63,6 +61,8 @@ class BoardControllerTest {
     void successCreateBoard() throws Exception {
         //given
         String email = "AAA";
+        HashSet<String> set = new HashSet<>();
+        set.add("nick name");
         given(tokenProvider.getEmailFromToken(any()))
                 .willReturn(email);
         given(boardService.creatBoard(anyString(), anyLong(), any()))
@@ -76,6 +76,7 @@ class BoardControllerTest {
                         .wineName("wine name")
                         .headcount(4)
                         .contents("hello world!")
+                        .participants(set)
                         .build());
         //when
         //then
@@ -103,6 +104,9 @@ class BoardControllerTest {
                 .andExpect(
                         jsonPath("$.contents")
                                 .value("hello world!"))
+                .andExpect(
+                        jsonPath("$.participants[0]")
+                                .value("nick name"))
                 .andDo(print());
     }
 
@@ -112,6 +116,8 @@ class BoardControllerTest {
     void successUpdateBoard() throws Exception {
         //given
         String email = "AAA";
+        HashSet<String> set = new HashSet<>();
+        set.add("nick name");
         given(tokenProvider.getEmailFromToken(any()))
                 .willReturn(email);
         given(boardService.updateBoard(anyString(), anyLong(), any()))
@@ -136,6 +142,7 @@ class BoardControllerTest {
                         .wineName("wine name")
                         .headcount(4)
                         .contents("hello world!")
+                        .participants(set)
                         .build()));
 
         //when
@@ -171,9 +178,45 @@ class BoardControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
+    void successParticipantInBoard() throws Exception {
+        //given
+        String email = "AAA";
+        given(tokenProvider.getEmailFromToken(any()))
+                .willReturn(email);
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add("Hong");
+        given(boardService.participantInBoard(anyString(), any()))
+                .willReturn(BoardParticipantResponse.builder()
+                        .name("A")
+                        .nickname("D")
+                        .winebarName("B")
+                        .date("2020-1-1")
+                        .time("7PM")
+                        .wineName("E")
+                        .headcount(3)
+                        .contents("F")
+                        .participants(partySet)
+                        .build());
+        //when
+        //then
+        mockMvc.perform(put("/boards/participants?board-id=1")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname").value("D"))
+                .andExpect(jsonPath("$.participants[0]").value("Hong"))
+                .andDo(print())
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
     @DisplayName("success Search Detail! - board")
     void successSearchBoardDetail() throws Exception {
         //given
+        HashSet<String> set = new HashSet<>();
+        set.add("nick name");
         given(boardService.searchBoardDetail(anyLong()))
                 .willReturn(BoardSearchDetailResponse.builder()
                         .name("A")
@@ -185,6 +228,7 @@ class BoardControllerTest {
                         .wineName("E")
                         .headcount(3)
                         .contents("F")
+                        .participants(set)
                         .build());
         //when
         //then
@@ -213,6 +257,7 @@ class BoardControllerTest {
                                 .wineName("wine")
                                 .headcount(4)
                                 .contents("content yo")
+                                .participants(1)
                                 .build(),
                         BoardSearchResponse.builder()
                                 .winebarName("wine bar2")
@@ -223,6 +268,7 @@ class BoardControllerTest {
                                 .wineName("wine2")
                                 .headcount(5)
                                 .contents("content yo2")
+                                .participants(1)
                                 .build(),
                         BoardSearchResponse.builder()
                                 .winebarName("wine bar3")
@@ -233,6 +279,7 @@ class BoardControllerTest {
                                 .wineName("wine3")
                                 .headcount(6)
                                 .contents("content yo3")
+                                .participants(1)
                                 .build()
                 );
         PageImpl<BoardSearchResponse> boardSearchResponsePage =
@@ -362,21 +409,6 @@ class BoardControllerTest {
     @DisplayName("success Delete - board")
     void successDeleteBoard() throws Exception {
         //given
-        String email = "AAA";
-        given(tokenProvider.getEmailFromToken(any()))
-                .willReturn(email);
-        given(boardService.creatBoard(anyString(), anyLong(), any()))
-                .willReturn(BoardCreateResponse.builder()
-                        .memberId(1L)
-                        .winebarId(1L)
-                        .name("board name")
-                        .nickname("nick name")
-                        .date("2010-1-1")
-                        .time("7AM")
-                        .wineName("wine name")
-                        .headcount(4)
-                        .contents("hello world!")
-                        .build());
         Long deletedBoardID = 1L;
         //when
         //then
@@ -497,6 +529,22 @@ class BoardControllerTest {
                                         .headcount(4)
                                         .contents("hello world!1")
                                         .build()))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
+                )
+                .andExpect(status().isOk())
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    void failedParticipantInBoard() throws Exception {
+        //given
+        given(boardService.participantInBoard(anyString(), anyLong()))
+                .willThrow(new RuntimeException("the board does not exist"));
+        //when
+        //then
+        mockMvc.perform(put("/boards/participants?board-id=1")
+                        .contentType(MediaType.APPLICATION_JSON).with(csrf())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
                 )
                 .andExpect(status().isOk())

--- a/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
@@ -445,6 +445,59 @@ class BoardServiceTest {
     }
 
     @Test
+    void successParticipantOutBoard() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Member member2 = Member.builder()
+                .id(10L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("creator!").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(16L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        Board targetBoard = Board.builder()
+                .id(1L).member(member1).winebar(winebar1).name("A").nickname("A")
+                .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                .time("7AM").participants(new HashSet<>())
+                .build();
+        targetBoard.deleteBoardParticipant(targetBoard,targetBoard.getNickname());
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(targetBoard));
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member2));
+        given(boardRepository.save(any())).willReturn(targetBoard);
+        //when
+        BoardParticipantResponse board = boardService
+                .participantInBoard("AAA", 1L);
+        //then
+        assertEquals(4, board.getHeadcount());
+        assertEquals("A", board.getNickname());
+        assertEquals("AA", board.getWinebarName());
+        assertEquals(1, board.getParticipants().size());
+        assertTrue(board.getParticipants().contains("creator!"));
+    }
+
+    @Test
     @DisplayName("success delete! - board")
     void successDeleteBoard() {
         //given

--- a/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
@@ -3,10 +3,7 @@ package com.be.friendy.warendy.domain.board.service;
 import com.be.friendy.warendy.config.jwt.TokenProvider;
 import com.be.friendy.warendy.domain.board.dto.request.BoardCreateRequest;
 import com.be.friendy.warendy.domain.board.dto.request.BoardUpdateRequest;
-import com.be.friendy.warendy.domain.board.dto.response.BoardCreateResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardSearchDetailResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardSearchResponse;
-import com.be.friendy.warendy.domain.board.dto.response.BoardUpdateResponse;
+import com.be.friendy.warendy.domain.board.dto.response.*;
 import com.be.friendy.warendy.domain.board.entity.Board;
 import com.be.friendy.warendy.domain.board.repository.BoardRepository;
 import com.be.friendy.warendy.domain.member.entity.Member;
@@ -28,11 +25,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -60,17 +57,19 @@ class BoardServiceTest {
     @DisplayName("success create! - board")
     void successCreateBoard() {
         //given
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add("Hong");
         Member member1 = Member.builder()
                 .id(13L)
                 .email("asdf@gmail.com")
                 .password("asdfasdfasdf")
-                .nickname("nick name").avatar("asdfasdfasdf")
+                .nickname("nick name1").avatar("asdfasdfasdf")
                 .mbti("istp")
                 .role(Role.MEMBER).oauthType("fasdf")
                 .body(1).dry(1).tannin(1).acidity(1)
                 .build();
         Winebar winebar1 = Winebar.builder()
-                .id(1L)
+                .id(14L)
                 .name("AA")
                 .picture("asdfasdf")
                 .address("tttttttt")
@@ -79,23 +78,25 @@ class BoardServiceTest {
                 .rating(1.1)
                 .reviews(1)
                 .build();
+        Board createdBoard = Board.builder()
+                .id(1L)
+                .member(member1)
+                .winebar(winebar1)
+                .name("A")
+                .nickname("A")
+                .date("2010-1-13")
+                .time("7AM")
+                .wineName("123")
+                .headcount(4)
+                .contents("123")
+                .participants(partySet)
+                .build();
         given(wineBarRepository.findById(anyLong()))
                 .willReturn(Optional.of(winebar1));
         given(memberRepository.findByEmail(anyString()))
                 .willReturn(Optional.of(member1));
         given(boardRepository.save(any()))
-                .willReturn(Board.builder()
-                        .id(1L)
-                        .member(member1)
-                        .winebar(winebar1)
-                        .name("A")
-                        .nickname("A")
-                        .date("2010-1-13")
-                        .time("7AM")
-                        .wineName("123")
-                        .headcount(4)
-                        .contents("123")
-                        .build());
+                .willReturn(createdBoard);
         //when
         BoardCreateRequest createRequest = BoardCreateRequest.builder()
                 .memberId(1L)
@@ -107,13 +108,15 @@ class BoardServiceTest {
                 .headcount(6)
                 .contents("hello world!")
                 .build();
+
         BoardCreateResponse createResponse =
                 boardService.creatBoard("AAA", 13L, createRequest);
         //then - given에서 값과 일치
         assertEquals(13L, createResponse.getMemberId());
-        assertEquals(1L, createResponse.getWinebarId());
+        assertEquals(14L, createResponse.getWinebarId());
         assertEquals("A", createResponse.getNickname());
         assertEquals(4, createResponse.getHeadcount());
+        assertEquals(1, createResponse.getParticipants().size());
     }
 
     @Test
@@ -138,10 +141,13 @@ class BoardServiceTest {
                 .rating(1.1)
                 .reviews(1)
                 .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
         Board board = Board.builder()
                 .id(1L).member(member1).winebar(winebar1).name("A")
                 .nickname("A").date("2010-1-13").time("7AM")
                 .wineName("123").headcount(4).contents("123")
+                .participants(partySet)
                 .build();
         given(boardRepository.findById(board.getId()))
                 .willReturn(Optional.of(board));
@@ -150,6 +156,7 @@ class BoardServiceTest {
                 = boardService.searchBoardDetail(1L);
         //then
         assertEquals("AA", boardDetailResponse.getWinebarName());
+        assertEquals(1, boardDetailResponse.getParticipants().size());
 
     }
 
@@ -175,21 +182,26 @@ class BoardServiceTest {
                 .rating(1.1)
                 .reviews(1)
                 .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
         List<Board> boardList = Arrays.asList(
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("A")
                         .nickname("A").date("2010-1-13").time("7AM")
                         .wineName("123").headcount(4).contents("123")
+                        .participants(partySet)
                         .build(),
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("Ab")
                         .nickname("Ab").date("2010-1-13b").time("7AM")
                         .wineName("123b").headcount(45).contents("123b")
+                        .participants(partySet)
                         .build(),
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("Ac")
                         .nickname("Ac").date("2010-1-13c").time("7AM")
                         .wineName("123c").headcount(46).contents("123c")
+                        .participants(partySet)
                         .build()
         );
         given(memberRepository.findByEmail(anyString()))
@@ -227,21 +239,26 @@ class BoardServiceTest {
                 .rating(1.1)
                 .reviews(1)
                 .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
         List<Board> boardList = Arrays.asList(
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("A")
                         .nickname("A").date("2010-1-13").time("7AM")
                         .wineName("123").headcount(4).contents("123")
+                        .participants(partySet)
                         .build(),
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("Ab")
                         .nickname("Ab").date("2010-1-13b").time("7AM")
                         .wineName("123b").headcount(45).contents("123b")
+                        .participants(partySet)
                         .build(),
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("Ac")
                         .nickname("Ac").date("2010-1-13c").time("7AM")
                         .wineName("123c").headcount(46).contents("123c")
+                        .participants(partySet)
                         .build()
         );
         given(wineBarRepository.findById(anyLong()))
@@ -280,25 +297,30 @@ class BoardServiceTest {
                 .rating(1.1)
                 .reviews(1)
                 .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
         List<Board> boardList = Arrays.asList(
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("A")
                         .nickname("A").date("2010-1-13").time("7AM")
                         .wineName("123").headcount(4).contents("123")
+                        .participants(partySet)
                         .build(),
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("Ab")
                         .nickname("Ab").date("2010-1-13b").time("7AM")
                         .wineName("123b").headcount(45).contents("123b")
+                        .participants(partySet)
                         .build(),
                 Board.builder()
                         .id(1L).member(member1).winebar(winebar1).name("Ac")
                         .nickname("Ac").date("2010-1-13c").time("7AM")
                         .wineName("123c").headcount(46).contents("123c")
+                        .participants(partySet)
                         .build()
         );
         given(memberRepository.findByNickname(anyString()))
-                .willReturn(Optional.ofNullable(member1));
+                .willReturn(Optional.of(member1));
         given(boardRepository.findByNickname(anyString(), any()))
                 .willReturn(new PageImpl<>(boardList));
         //when
@@ -336,10 +358,12 @@ class BoardServiceTest {
                 .rating(1.1)
                 .reviews(1)
                 .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
         Board targetBoard = Board.builder()
                 .id(1L).member(member1).winebar(winebar1).name("A").nickname("A")
                 .date("2010-1-13").wineName("123").headcount(4).contents("123")
-                .time("7AM")
+                .time("7AM").participants(partySet)
                 .build();
         given(boardRepository.findById(anyLong()))
                 .willReturn(Optional.of(targetBoard));
@@ -359,11 +383,65 @@ class BoardServiceTest {
                 .headcount(5)
                 .contents("empty at all")
                 .build();
-        BoardUpdateResponse board = boardService.updateBoard("AAA", 13L, request);
+        BoardUpdateResponse board = boardService
+                .updateBoard("AAA", 13L, request);
         //then
         assertEquals(5, board.getHeadcount());
         assertEquals("creator!", board.getNickname());
         assertEquals("AAA", board.getWineName());
+    }
+
+    @Test
+    void successParticipantInBoard() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Member member2 = Member.builder()
+                .id(10L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("creator!").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(16L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        Board targetBoard = Board.builder()
+                .id(1L).member(member1).winebar(winebar1).name("A").nickname("A")
+                .date("2010-1-13").wineName("123").headcount(4).contents("123")
+                .time("7AM").participants(new HashSet<>())
+                .build();
+        targetBoard.insertBoardParticipant(targetBoard,targetBoard.getNickname());
+        given(boardRepository.findById(anyLong()))
+                .willReturn(Optional.of(targetBoard));
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member2));
+        given(boardRepository.save(any())).willReturn(targetBoard);
+        //when
+        BoardParticipantResponse board = boardService
+                .participantInBoard("AAA", 1L);
+        //then
+        assertEquals(4, board.getHeadcount());
+        assertEquals("A", board.getNickname());
+        assertEquals("AA", board.getWinebarName());
+        assertEquals(2, board.getParticipants().size());
+        assertTrue(board.getParticipants().contains("creator!"));
     }
 
     @Test
@@ -532,6 +610,17 @@ class BoardServiceTest {
                                 .headcount(1)
                                 .contents("cont")
                                 .build()));
+        //then
+        assertEquals("the board does not exist", exception.getMessage());
+    }
+
+    @Test
+    void failedParticipantInBoardNotFoundBoard() {
+        //given
+        given(boardRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> boardService.participantInBoard("AAA", 1L));
         //then
         assertEquals("the board does not exist", exception.getMessage());
     }


### PR DESCRIPTION
### Validation
board headcount 양수 만 가능.
-  #### Changes
    -  의존성 추가: implementation 'org.springframework.boot:spring-boot-starter-validation'
    -  board Entity의 headcount에 @Positive 어노테이션 추가.
    -  controller createBoard, updateBoard에 @Valid 어노테이션 추가.

### Transcation
서비스 단에 트랜잭션 설정 추가.
-  #### Changes
    -  creatBoard : @Transactional(timeout = 30),  실행 시간으로 인해 성능 문제가 발생하지 않도록 제한 시간 값을 설정.
    -  searchBoardDetail :  @Transactional(readOnly = true), 데이터를 검색하고 수정하지 않는 메서드에 대해 읽기 전용으로 표시하여 성능 향상.
    -  updateBoard, deleteBoard : @Transactional(propagation = Propagation.REQUIRED, rollbackFor = {RuntimeException.class}), 기존 트랜잭션에 참여하거나 트랜잭션이 없는 경우 새로운 트랜잭션을 시작/롤백을 유발해야 하는 예외를 포함

### 동행 참여하기 기능 추가
설정한 headcount 수 만큼 동행에 참여하는, 참여 취소하는 기능.
-  #### Changes
    -  responseDTO : BoardParticipantResponse
    -  board : insertBoardParticipant, deleteBoardParticipant - 참가자 업데이트
    -  controller : boardParticipant, boardParticipantOut
    -  service : participantInBoard, participantOutBoard
    -  테스트코드 추가.
