### PR TITLE
refactor 동행 게시글 지역 컬럼, 지역으로 검색 기능 추가

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -71,7 +71,7 @@ public class BoardController {
     @GetMapping("/wine-name")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByWineName(
             @RequestParam String wineName,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService
                 .searchBoardByWineName(wineName, pageable));
@@ -80,7 +80,7 @@ public class BoardController {
     @GetMapping("/winebar-id")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByWinebarId(
             @RequestParam(value = "winebar-id") Long winebarId,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService
                 .searchBoardByWinebarId(winebarId, pageable));
@@ -89,7 +89,7 @@ public class BoardController {
     @GetMapping("/winebar-name")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByWinebarName(
             @RequestParam String winebarName,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService
                 .searchBoardByWinebarName(winebarName, pageable));
@@ -98,7 +98,7 @@ public class BoardController {
     @GetMapping("/creator")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByCreator(
             @RequestParam String creator,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(
                 boardService.searchBoardByCreator(creator, pageable)
@@ -108,7 +108,7 @@ public class BoardController {
     @GetMapping("/date")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByDate(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService.searchBoardByDate(date, pageable));
     }
@@ -116,15 +116,17 @@ public class BoardController {
     @GetMapping("/time")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByTime(
             @RequestParam String time,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return ResponseEntity.ok(boardService.searchBoardByTime(time, pageable));
     }
 
     @GetMapping("/region")
     public ResponseEntity<?> boardSearchByRegion(
+            @RequestParam String region,
+            @PageableDefault(size = 10) Pageable pageable
     ) {
-        return null;
+        return ResponseEntity.ok(boardService.searchBoardByRegion(region, pageable));
     }
 
     @PutMapping("/{board-id}")

--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -122,7 +122,7 @@ public class BoardController {
     }
 
     @GetMapping("/region")
-    public ResponseEntity<?> boardSearchByRegion(
+    public ResponseEntity<Page<BoardSearchResponse>> boardSearchByRegion(
             @RequestParam String region,
             @PageableDefault(size = 10) Pageable pageable
     ) {

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardCreateRequest.java
@@ -24,6 +24,8 @@ public class BoardCreateRequest {
 
     private String time;
 
+    private String region;
+
     private String wineName;
 
     private Integer headcount;
@@ -38,6 +40,7 @@ public class BoardCreateRequest {
                 .nickname(member.getNickname())
                 .date(date)
                 .time(time)
+                .region(region)
                 .wineName(wineName)
                 .headcount(headcount)
                 .contents(contents)

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/request/BoardUpdateRequest.java
@@ -16,6 +16,7 @@ public class BoardUpdateRequest {
     private String nickname;
     private String date;
     private String time;
+    private String region;
     private String wineName;
     private Integer headcount;
     private String contents;

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardCreateResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardCreateResponse.java
@@ -21,6 +21,7 @@ public class BoardCreateResponse {
     private String nickname;
     private String date;
     private String time;
+    private String region;
     private String wineName;
     private Integer headcount;
     private String contents;
@@ -35,6 +36,7 @@ public class BoardCreateResponse {
                 .nickname(board.getNickname())
                 .date(board.getDate())
                 .time(board.getTime())
+                .region(board.getRegion())
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardParticipantResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardParticipantResponse.java
@@ -21,6 +21,7 @@ public class BoardParticipantResponse {
     private String winebarName;
     private String date;
     private String time;
+    private String region;
     private String wineName;
     private Integer headcount;
     private String contents;
@@ -34,6 +35,7 @@ public class BoardParticipantResponse {
                 .winebarName(board.getWinebar().getName())
                 .date(board.getDate())
                 .time(board.getTime())
+                .region(board.getRegion())
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchDetailResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchDetailResponse.java
@@ -19,6 +19,7 @@ public class BoardSearchDetailResponse {
     private String nickname;
     private String date;
     private String time;
+    private String region;
     private String wineName;
     private Integer headcount;
     private String contents;
@@ -32,6 +33,7 @@ public class BoardSearchDetailResponse {
                 .nickname(board.getNickname())
                 .date(board.getDate())
                 .time(board.getTime())
+                .region(board.getRegion())
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardSearchResponse.java
@@ -18,6 +18,7 @@ public class BoardSearchResponse {
     private String nickname;
     private String date;
     private String time;
+    private String region;
     private String wineName;
     private Integer headcount;
     private String contents;
@@ -30,6 +31,7 @@ public class BoardSearchResponse {
                 .nickname(board.getNickname())
                 .date(board.getDate())
                 .time(board.getTime())
+                .region(board.getRegion())
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())

--- a/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/dto/response/BoardUpdateResponse.java
@@ -17,6 +17,7 @@ public class BoardUpdateResponse {
     private String winebarName;
     private String date;
     private String time;
+    private String region;
     private String wineName;
     private Integer headcount;
     private String contents;
@@ -29,6 +30,7 @@ public class BoardUpdateResponse {
                 .winebarName(board.getWinebar().getName())
                 .date(board.getDate())
                 .time(board.getTime())
+                .region(board.getRegion())
                 .wineName(board.getWineName())
                 .headcount(board.getHeadcount())
                 .contents(board.getContents())

--- a/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/entity/Board.java
@@ -46,6 +46,7 @@ public class Board extends BaseEntity {
     private String nickname;
     private String date;
     private String time;
+    private String region;
     private String wineName;
 
     @Positive(message = "Headcount must be a positive number")
@@ -60,6 +61,7 @@ public class Board extends BaseEntity {
         nickname = request.getNickname();
         date = request.getDate();
         time = request.getTime();
+        region = request.getRegion();
         wineName = request.getWineName();
         headcount = request.getHeadcount();
         contents = request.getContents();

--- a/src/main/java/com/be/friendy/warendy/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/repository/BoardRepository.java
@@ -28,5 +28,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Page<Board> findByTime(String time, Pageable pageable);
 
+    Page<Board> findByRegion(String region, Pageable pageable);
+
     boolean existsByName(String name);
 }

--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -56,6 +56,7 @@ public class BoardService {
                         .nickname(createRequest.getNickname())
                         .date(createRequest.getDate())
                         .time(createRequest.getTime())
+                        .region(createRequest.getRegion())
                         .wineName(createRequest.getWineName())
                         .headcount(createRequest.getHeadcount())
                         .contents(createRequest.getContents())
@@ -146,6 +147,13 @@ public class BoardService {
             String time, Pageable pageable
     ) {
         return boardRepository.findByTime(time, pageable)
+                .map(BoardSearchResponse::fromEntity);
+    }
+
+    public Page<BoardSearchResponse> searchBoardByRegion(
+            String region, Pageable pageable
+    ) {
+        return boardRepository.findByRegion(region, pageable)
                 .map(BoardSearchResponse::fromEntity);
     }
 

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/dto/response/WinebarSearchResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/dto/response/WinebarSearchResponse.java
@@ -21,6 +21,8 @@ public class WinebarSearchResponse {
 
     private String picture;
 
+    private String region;
+
     private String address;
 
     private Double lnt;
@@ -34,11 +36,15 @@ public class WinebarSearchResponse {
     private List<BoardSearchResponse> boardList;
 
     public static WinebarSearchResponse fromEntity(Winebar winebar) {
+        String address = winebar.getAddress();
+        String regionFromAddress = address.split(" ")[0];
+
         return WinebarSearchResponse.builder()
                 .winebarId(winebar.getId())
                 .name(winebar.getName())
                 .picture(winebar.getPicture())
-                .address(winebar.getAddress())
+                .region(regionFromAddress)
+                .address(address)
                 .lnt(winebar.getLnt())
                 .lat(winebar.getLat())
                 .rating(winebar.getRating())

--- a/src/main/java/com/be/friendy/warendy/domain/winebar/entity/Winebar.java
+++ b/src/main/java/com/be/friendy/warendy/domain/winebar/entity/Winebar.java
@@ -28,6 +28,8 @@ public class Winebar extends BaseEntity {
 
     private String picture;
 
+    private String region;
+
     private String address;
 
     private Double lnt;

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -440,6 +440,62 @@ class BoardControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Search with a Region! - board")
+    void successSearchBoardByRegion() throws Exception {
+        //given
+        List<BoardSearchResponse> boardSearchResponses =
+                Arrays.asList(
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar")
+                                .name("board")
+                                .nickname("Hong")
+                                .date("2000-1-1")
+                                .time("7AM")
+                                .region("seoul")
+                                .wineName("wine")
+                                .headcount(4)
+                                .contents("content yo")
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar2")
+                                .name("board2")
+                                .nickname("Hong")
+                                .date("2000-1-12")
+                                .time("10AM")
+                                .region("seoul")
+                                .wineName("wine2")
+                                .headcount(5)
+                                .contents("content yo2")
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar3")
+                                .name("board3")
+                                .nickname("Hong")
+                                .date("2000-1-13")
+                                .time("8AM")
+                                .region("seoul")
+                                .wineName("wine3")
+                                .headcount(6)
+                                .contents("content yo3")
+                                .build()
+                );
+        PageImpl<BoardSearchResponse> boardSearchResponsePage =
+                new PageImpl<>(boardSearchResponses);
+        given(boardService.searchBoardByRegion(anyString(), any()))
+                .willReturn(boardSearchResponsePage);
+        //when
+        //then
+        mockMvc.perform(get("/boards/region?region=1&page=0"))
+                .andDo(print())
+                .andExpect(jsonPath("$.content[0].nickname")
+                        .value("Hong"))
+                .andExpect(jsonPath("$.content[0].region")
+                        .value("seoul"))
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
     @DisplayName("success Delete - board")
     void successDeleteBoard() throws Exception {
         //given

--- a/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
@@ -336,6 +336,66 @@ class BoardServiceTest {
     }
 
     @Test
+    @DisplayName("success search with a region! - board")
+    void successSearchBoardByRegion() {
+        //given
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(1L)
+                .name("AA")
+                .picture("asdfasdf")
+                .region("서울")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
+        List<Board> boardList = Arrays.asList(
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("A")
+                        .nickname("A").date("2010-1-13").time("7AM")
+                        .wineName("123").headcount(4).contents("123")
+                        .participants(partySet).region("경북")
+                        .build(),
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("Ab")
+                        .nickname("Ab").date("2010-1-13b").time("7AM")
+                        .wineName("123b").headcount(45).contents("123b")
+                        .participants(partySet).region("경남")
+                        .build(),
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("Ac")
+                        .nickname("Ac").date("2010-1-13c").time("7AM")
+                        .wineName("123c").headcount(46).contents("123c")
+                        .participants(partySet).region("호남")
+                        .build()
+        );
+        given(boardRepository.findByRegion(anyString(), any()))
+                .willReturn(new PageImpl<>(boardList));
+        //when
+        Pageable pageable = PageRequest.of(0, 3);
+        Page<BoardSearchResponse> boardPage
+                = boardService.searchBoardByRegion("a", pageable);
+        //then
+        assertEquals(3, boardPage.getTotalElements());
+        assertEquals(1, boardPage.getTotalPages());
+        assertEquals("경북", boardPage.getContent().get(0).getRegion());
+        assertEquals("경남", boardPage.getContent().get(1).getRegion());
+        assertEquals("호남", boardPage.getContent().get(2).getRegion());
+    }
+
+    @Test
     @DisplayName("success update! - board")
     void successUpdateBoard() {
         //given


### PR DESCRIPTION
### 동행 게시글 지역 검색 추가
지역 컬럼을 추가해, 동행 게시글 검색 시 지역 필터 제공.

-  #### changes
    -  Board Entity, DTO : String region 추가.
    -  Board Controller  : Page<BoardSearchResponse>  boardSearchByRegion()
    -  Board Service : Page<BoardSearchResponse> searchBoardByRegion()
    -  지역으로 보드 조회 테스트 진행.
