### PR TITLE
refactor: 내가 참여한 동행 게시글 조회 기능 추가

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/controller/BoardController.java
@@ -59,6 +59,14 @@ public class BoardController {
         return ResponseEntity.ok(boardService.searchMyBoardByEmail(email, pageable));
     }
 
+    @GetMapping("/in-party")
+    public ResponseEntity<Page<BoardSearchResponse>> boardSearchParticipantInBoards(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String email = tokenProvider.getEmailFromToken(authorizationHeader);
+        return ResponseEntity.ok(boardService.searchParticipantInBoards(email));
+    }
+
     @GetMapping("/board-name")
     public ResponseEntity<Page<BoardSearchResponse>> boardSearchByBoardName(
             @RequestParam String boardName,

--- a/src/main/java/com/be/friendy/warendy/domain/member/dto/response/InfoResponse.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/dto/response/InfoResponse.java
@@ -15,7 +15,8 @@ public record InfoResponse (
         int body,
         int dry,
         int tannin,
-        int acidity
+        int acidity,
+        String InBoardIdList
 ) {
 
     public static InfoResponse fromEntity(Member member) {
@@ -27,6 +28,7 @@ public record InfoResponse (
                 .dry(member.getDry())
                 .tannin(member.getTannin())
                 .acidity(member.getAcidity())
+                .InBoardIdList(member.getInBoardIdList())
                 .build();
     }
 }

--- a/src/main/java/com/be/friendy/warendy/domain/member/entity/Member.java
+++ b/src/main/java/com/be/friendy/warendy/domain/member/entity/Member.java
@@ -43,6 +43,37 @@ public class Member extends BaseEntity {
     private int tannin;
     private int acidity;
 
+    private String inBoardIdList;
+
+    public void InBoard(Long boardId) {
+
+        if(inBoardIdList != null){
+            StringBuilder targetBoard = new StringBuilder();
+            targetBoard.append(boardId).append(",");
+            if(inBoardIdList.contains(targetBoard.toString())
+                    || inBoardIdList.contains(String.valueOf(boardId))) {
+
+            } else {
+                targetBoard.append(inBoardIdList);
+                inBoardIdList = targetBoard.toString();
+            }
+        } else {
+            inBoardIdList = String.valueOf(boardId);
+        }
+
+    }
+
+    public void OutBoard(Long boardId) {
+
+        String targetBoard = boardId + ",";
+        if(inBoardIdList.contains(targetBoard)){
+            inBoardIdList = inBoardIdList.replace(targetBoard,"");
+        } else {
+            inBoardIdList = inBoardIdList.replace(
+                    String.valueOf(boardId),"");
+        }
+    }
+
     // Member 엔티티에서 원하는 필드만 수정하는 메서드
     public void updateMemberInfo(String email, String password, String nickname,
                                  String avatar, Integer body,

--- a/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/controller/BoardControllerTest.java
@@ -335,6 +335,67 @@ class BoardControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
+    @DisplayName("success Search My board! - board")
+    void successSearchParticipantInBoards() throws Exception {
+        //given
+        String email = "AAA";
+        given(tokenProvider.getEmailFromToken(any()))
+                .willReturn(email);
+        List<BoardSearchResponse> boardSearchResponses =
+                Arrays.asList(
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar")
+                                .name("board")
+                                .nickname("Hong")
+                                .date("2000-1-1")
+                                .time("7AM")
+                                .wineName("wine")
+                                .headcount(4)
+                                .contents("content yo")
+                                .participants(1)
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar2")
+                                .name("board2")
+                                .nickname("Hong")
+                                .date("2000-1-12")
+                                .time("10AM")
+                                .wineName("wine2")
+                                .headcount(5)
+                                .contents("content yo2")
+                                .participants(1)
+                                .build(),
+                        BoardSearchResponse.builder()
+                                .winebarName("wine bar3")
+                                .name("board3")
+                                .nickname("Hong")
+                                .date("2000-1-13")
+                                .time("8AM")
+                                .wineName("wine3")
+                                .headcount(6)
+                                .contents("content yo3")
+                                .participants(1)
+                                .build()
+                );
+        PageImpl<BoardSearchResponse> boardSearchResponsePage =
+                new PageImpl<>(boardSearchResponses);
+        given(boardService.searchParticipantInBoards(anyString()))
+                .willReturn(boardSearchResponsePage);
+        //when
+        //then
+        mockMvc.perform(get("/boards/in-party?page=1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ACCESS_TOKEN")
+                )
+                .andDo(print())
+                .andExpect(jsonPath("$.content[0].nickname")
+                        .value("Hong"))
+                .andExpect(jsonPath("$.content[1].nickname")
+                        .value("Hong"))
+        ;
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
     void successSearchBoardByWinebarId() throws Exception {
         //given
         List<BoardSearchResponse> boardSearchResponses =

--- a/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/be/friendy/warendy/domain/board/service/BoardServiceTest.java
@@ -24,10 +24,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -212,6 +209,68 @@ class BoardServiceTest {
         Pageable pageable = PageRequest.of(0, 3);
         Page<BoardSearchResponse> MyBoardPage
                 = boardService.searchMyBoardByEmail("AAA", pageable);
+        //then
+        assertEquals(3, MyBoardPage.getTotalElements());
+        assertEquals(1, MyBoardPage.getTotalPages());
+    }
+
+    @Test
+    void successSearchParticipantInBoard() {
+        //given
+        String boardIdList = "4,1,2";
+        Member member1 = Member.builder()
+                .id(13L)
+                .email("asdf@gmail.com")
+                .password("asdfasdfasdf")
+                .nickname("nick name").avatar("asdfasdfasdf")
+                .mbti("istp")
+                .role(Role.MEMBER).oauthType("fasdf")
+                .body(1).dry(1).tannin(1).acidity(1)
+                .inBoardIdList(boardIdList)
+                .build();
+        Winebar winebar1 = Winebar.builder()
+                .id(1L)
+                .name("AA")
+                .picture("asdfasdf")
+                .address("tttttttt")
+                .lat(0.0)
+                .lnt(0.0)
+                .rating(1.1)
+                .reviews(1)
+                .build();
+        HashSet<String> partySet = new HashSet<>();
+        partySet.add(member1.getNickname());
+        List<Board> boardList = Arrays.asList(
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("A")
+                        .nickname("A").date("2010-1-13").time("7AM")
+                        .wineName("123").headcount(4).contents("123")
+                        .participants(partySet)
+                        .build(),
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("Ab")
+                        .nickname("Ab").date("2010-1-13b").time("7AM")
+                        .wineName("123b").headcount(45).contents("123b")
+                        .participants(partySet)
+                        .build(),
+                Board.builder()
+                        .id(1L).member(member1).winebar(winebar1).name("Ac")
+                        .nickname("Ac").date("2010-1-13c").time("7AM")
+                        .wineName("123c").headcount(46).contents("123c")
+                        .participants(partySet)
+                        .build()
+        );
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member1));
+        for(Board board  : boardList) {
+            given(boardRepository.existsById(anyLong())).willReturn(true);
+            given(boardRepository.findById(anyLong()))
+                    .willReturn(Optional.of(board));
+        }
+        //when
+        Pageable pageable = PageRequest.of(0, 3);
+        Page<BoardSearchResponse> MyBoardPage
+                = boardService.searchParticipantInBoards("AAA");
         //then
         assertEquals(3, MyBoardPage.getTotalElements());
         assertEquals(1, MyBoardPage.getTotalPages());
@@ -492,6 +551,7 @@ class BoardServiceTest {
                 .willReturn(Optional.of(targetBoard));
         given(memberRepository.findByEmail(anyString()))
                 .willReturn(Optional.of(member2));
+        given(memberRepository.save(any())).willReturn(member2);
         given(boardRepository.save(any())).willReturn(targetBoard);
         //when
         BoardParticipantResponse board = boardService
@@ -545,6 +605,7 @@ class BoardServiceTest {
                 .willReturn(Optional.of(targetBoard));
         given(memberRepository.findByEmail(anyString()))
                 .willReturn(Optional.of(member2));
+        given(memberRepository.save(any())).willReturn(member2);
         given(boardRepository.save(any())).willReturn(targetBoard);
         //when
         BoardParticipantResponse board = boardService


### PR DESCRIPTION
### 내가 참여한 동행 게시글 조회 기능
마이페이지와, 동행 게시글 페이지에서 내가 참여한 동행 게시글 조회할 수 있는 기능.

-  #### changes
    -  member DTO  :   String InBoardIdList 추가. 
    -  member entity
        - String InBoardIdList, 참여한 보드 리스트 스트링화한 컬럼 추가.
        - InBoard(Long boardId), OutBoard(Long boardId) : 보드 id를 넣고 빼는 함수. 내가 가장 최근에 참여한 보드 순으로 정렬.
    -  board controller
        -   boardSearchParticipantInBoards() : 내가 참여한 보드 조회하는 함수 추가, URL : GetMapping("/boards/in-party").
    -  board service
        -  searchParticipantInBoards() : 내가 참여한 보드 검색하는 함수 추가. 