### PR TITLE
fix: inBoardList null 일 때 에러 수정

### DIFF
--- a/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
+++ b/src/main/java/com/be/friendy/warendy/domain/board/service/BoardService.java
@@ -95,6 +95,10 @@ public class BoardService {
         Member memberByEmail = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("user does not exist"));
 
+        if(memberByEmail.getInBoardIdList() == null) {
+            return new PageImpl<>(new ArrayList<>());
+        }
+
         String[] boardIdList = memberByEmail.getInBoardIdList().split(",");
         List<Board> boardInPartyList = new ArrayList<>();
         for (String boardId : boardIdList) {


### PR DESCRIPTION
#### changes
-  board service :  if(memberByEmail.getInBoardIdList() == null) {return new PageImpl<>(new ArrayList<>());} 추가
#### 상세 설명
null로 인해 String.split(String) 할 수 없어 오류 발생 -> 빈 값 리턴하게 수정.

